### PR TITLE
CORDA-3228: Implement a filter to exclude entire classloaders.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ subprojects {
     }
 
     group               = "co.paralleluniverse"
-    version             = "0.7.11_r3"
+    version             = "0.7.12_r3"
     status              = "integration"
     description         = "Fibers, Channels and Actors for the JVM"
     ext.url             = "http://puniverse.github.com/quasar"

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
@@ -95,6 +95,7 @@ import static co.paralleluniverse.fibers.instrument.QuasarInstrumentor.ASMAPI;
  * @author Matthias Mann
  */
 public class JavaAgent {
+    private static final String USAGE = "Usage: vdmcbx(exclusion;...)l(exclusion;...) (verbose, debug, allow monitors, check class, allow blocking)";
     private static volatile boolean ACTIVE;
     private static final Set<WeakReference<ClassLoader>> classLoaders = Collections.newSetFromMap(MapUtil.<WeakReference<ClassLoader>, Boolean>newConcurrentHashMap());
 
@@ -102,7 +103,6 @@ public class JavaAgent {
         if (!instrumentation.isRetransformClassesSupported())
             System.err.println("Retransforming classes is not supported!");
 
-        final ClassLoader cl = Thread.currentThread().getContextClassLoader();
         final QuasarInstrumentor instrumentor = new QuasarInstrumentor(false);
         ACTIVE = true;
         SuspendableHelper.javaAgent = true;
@@ -135,11 +135,10 @@ public class JavaAgent {
                         i++;
                         c = agentArguments.charAt(i);
                         if (c != '(')
-                            throw new IllegalStateException("Usage: vdmcbx(exclusion;...) (verbose, debug, allow monitors, check class, allow blocking)");
-                        i++;
+                            throw new IllegalStateException(USAGE);
                         StringBuilder sb = new StringBuilder();
                         while(true) {
-                            c = agentArguments.charAt(i++);
+                            c = agentArguments.charAt(++i);
                             if (c == ')')
                                 break;
                             sb.append(c);
@@ -149,8 +148,24 @@ public class JavaAgent {
                             instrumentor.addExcludedPackage(x);
                         break;
 
+                    case 'l':
+                        ++i;
+                        c = agentArguments.charAt(i);
+                        if (c != '(') {
+                            throw new IllegalStateException(USAGE);
+                        }
+                        int j = agentArguments.indexOf(')', ++i);
+                        if (j == -1) {
+                            throw new IllegalStateException(USAGE);
+                        }
+                        String[] classLoaderExclusions = agentArguments.substring(i, j).split(";", 0);
+                        for (String x : classLoaderExclusions) {
+                            instrumentor.addExcludedClassLoader(x);
+                        }
+                        i = j;
+                        break;
                     default:
-                        throw new IllegalStateException("Usage: vdmcbx(exclusion;...) (verbose, debug, allow monitors, check class, allow blocking)");
+                        throw new IllegalStateException(USAGE);
                 }
             }
         }
@@ -192,6 +207,17 @@ public class JavaAgent {
 
         @Override
         public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+            if (loader == null) {
+                loader = Thread.currentThread().getContextClassLoader();
+                if (loader == null) {
+                    loader = ClassLoader.getSystemClassLoader();
+                }
+            }
+
+            if (!instrumentor.shouldInstrument(loader)) {
+                return null;
+            }
+
             if (className != null && className.startsWith("clojure/lang/Compiler"))
                 return crazyClojureOnceDisable(loader, className, classBeingRedefined, protectionDomain, classfileBuffer);
 
@@ -203,9 +229,6 @@ public class JavaAgent {
             classLoaders.add(new WeakReference<>(loader));
 
             try {
-                if (loader == null)
-                    loader = Thread.currentThread().getContextClassLoader();
-
                 final byte[] transformed = instrumentor.instrumentClass(loader, className, classfileBuffer);
 
                 if (transformed != null)

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarInstrumentor.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarInstrumentor.java
@@ -48,6 +48,7 @@ public final class QuasarInstrumentor {
     private boolean allowMonitors;
     private boolean allowBlocking;
     private final Collection<Pattern> exclusions = new ArrayList<>();
+    private final Collection<Pattern> excludedClassLoaders = new ArrayList<>();
     private Log log;
     private boolean verbose;
     private boolean debug;
@@ -65,6 +66,11 @@ public final class QuasarInstrumentor {
     @SuppressWarnings("unused")
     public boolean isAOT() {
         return aot;
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public boolean shouldInstrument(ClassLoader loader) {
+        return loader != null && !isExcludedClassLoader(loader.getClass().getName());
     }
 
     @SuppressWarnings("WeakerAccess")
@@ -265,6 +271,54 @@ public final class QuasarInstrumentor {
             }
         }
         return false;
+    }
+
+    synchronized boolean isExcludedClassLoader(String classLoaderName) {
+        for (Pattern pattern : excludedClassLoaders) {
+            if (pattern.matcher(classLoaderName).matches())
+                return true;
+        }
+        return false;
+    }
+
+    public synchronized void addExcludedClassLoader(String glob) {
+        excludedClassLoaders.add(classLoaderPattern(glob));
+    }
+
+    private static Pattern classLoaderPattern(String glob) {
+        StringBuilder out = new StringBuilder(glob.length() + 5).append('^');
+        int i = 0;
+        while (i < glob.length()) {
+            final char c = glob.charAt(i);
+            switch (c) {
+                case '.':
+                    out.append("\\.");
+                    break;
+                case '?':
+                    out.append('.');
+                    break;
+                case '*':
+                    int j = i + 1;
+                    if (j < glob.length()) {
+                        char next = glob.charAt(j);
+                        if (next == '*') {
+                            out.append(".*");
+                            ++i;
+                            break;
+                        }
+                    }
+                    out.append("[^.]+");
+                    break;
+                case '$':
+                    out.append("\\$");
+                    break;
+                default:
+                    out.append(c);
+            }
+            ++i;
+        }
+        out.append('$');
+        return Pattern.compile(out.toString());
     }
 
     private synchronized void setLogLevelMask() {

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/ClassLoaderExclusionTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/ClassLoaderExclusionTest.java
@@ -1,0 +1,140 @@
+package co.paralleluniverse.fibers.instrument;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ClassLoaderExclusionTest {
+    private QuasarInstrumentor instrumentor;
+
+    @Before
+    public void setup() {
+        instrumentor = new QuasarInstrumentor(false);
+    }
+
+    @Test
+    public void testAcceptWhenNoExclusions() {
+        assertFalse(instrumentor.isExcludedClassLoader("X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.c.X"));
+    }
+
+    @Test
+    public void testRejectingEverything() {
+        instrumentor.addExcludedClassLoader("**");
+        assertTrue(instrumentor.isExcludedClassLoader("X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.c.X"));
+    }
+
+    @Test
+    public void testRejectingDefaultPackageOnly() {
+        instrumentor.addExcludedClassLoader("*");
+        assertTrue(instrumentor.isExcludedClassLoader("X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.c.X"));
+    }
+
+    @Test
+    public void testRejectingFirstLevel() {
+        instrumentor.addExcludedClassLoader("*.*");
+        assertFalse(instrumentor.isExcludedClassLoader("X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.c.X"));
+    }
+
+    @Test
+    public void testRejectingFirstLevelAndBelow() {
+        instrumentor.addExcludedClassLoader("*.**");
+        assertFalse(instrumentor.isExcludedClassLoader("X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.c.X"));
+    }
+
+    @Test
+    public void testRejectingSecondLevel() {
+        instrumentor.addExcludedClassLoader("*.*.*");
+        assertFalse(instrumentor.isExcludedClassLoader("X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.c.X"));
+    }
+
+    @Test
+    public void testRejectingSecondLevelAndBelow() {
+        instrumentor.addExcludedClassLoader("*.*.**");
+        assertFalse(instrumentor.isExcludedClassLoader("X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.c.X"));
+    }
+
+    @Test
+    public void testRejectingThirdLevel() {
+        instrumentor.addExcludedClassLoader("*.*.*.*");
+        assertFalse(instrumentor.isExcludedClassLoader("X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.c.X"));
+    }
+
+    @Test
+    public void testRejectingThirdLevelAndBelow() {
+        instrumentor.addExcludedClassLoader("*.*.*.**");
+        assertFalse(instrumentor.isExcludedClassLoader("X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.c.X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.c.d.X"));
+    }
+
+    @Test
+    public void testRejectingSpecificLoader() {
+        instrumentor.addExcludedClassLoader("**.LOADER");
+        assertTrue(instrumentor.isExcludedClassLoader("a.LOADER"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.LOADER"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.c.LOADER"));
+
+        assertFalse(instrumentor.isExcludedClassLoader("a.LOAD"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.LOAD"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.c.LOAD"));
+    }
+
+    @Test
+    public void testRejectingBySingleCharcterGlobs() {
+        instrumentor.addExcludedClassLoader("**.?X");
+        assertTrue(instrumentor.isExcludedClassLoader("a.1X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.1X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.c.1X"));
+
+        assertTrue(instrumentor.isExcludedClassLoader("a.2X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.2X"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.c.2X"));
+
+        assertFalse(instrumentor.isExcludedClassLoader("a.X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.c.X"));
+    }
+
+    @Test
+    public void testRejectingnamesWithDollars() {
+        instrumentor.addExcludedClassLoader("**.X$Y");
+        assertTrue(instrumentor.isExcludedClassLoader("a.X$Y"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.X$Y"));
+        assertTrue(instrumentor.isExcludedClassLoader("a.b.c.X$Y"));
+
+        assertFalse(instrumentor.isExcludedClassLoader("a.XY"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.XY"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.c.XY"));
+
+        assertFalse(instrumentor.isExcludedClassLoader("a.X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.X"));
+        assertFalse(instrumentor.isExcludedClassLoader("a.b.c.X"));
+    }
+}


### PR DESCRIPTION
Modify Quasar's Java agent so that we can exclude all classes belonging to any classloader that matches one of our patterns.