### PR TITLE
CORDA-3673: Add support for running with a SecurityManager installed.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -899,7 +899,7 @@ artifactory {
     publish {
         contextUrl = 'https://ci-artifactory.corda.r3cev.com/artifactory'
         repository {
-            repoKey = 'corda-dependencies'
+            repoKey = 'corda-dependencies-dev'
             username = System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: System.getProperty('corda.artifactory.username')
             password = System.getenv('CORDA_ARTIFACTORY_PASSWORD') ?: System.getProperty('corda.artifactory.password')
             maven = true

--- a/quasar-core/src/main/java/co/paralleluniverse/common/reflection/GetAccessDeclaredConstructor.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/reflection/GetAccessDeclaredConstructor.java
@@ -1,0 +1,21 @@
+package co.paralleluniverse.common.reflection;
+
+import java.lang.reflect.Constructor;
+import java.security.PrivilegedExceptionAction;
+
+public class GetAccessDeclaredConstructor<T> implements PrivilegedExceptionAction<Constructor<T>> {
+    private final Class<T> clazz;
+    private final Class<?>[] args;
+
+    public GetAccessDeclaredConstructor(Class<T> clazz, Class<?>... args) {
+        this.clazz = clazz;
+        this.args = args;
+    }
+
+    @Override
+    public Constructor<T> run() throws NoSuchMethodException {
+        Constructor<T> constructor = clazz.getDeclaredConstructor(args);
+        constructor.setAccessible(true);
+        return constructor;
+    }
+}

--- a/quasar-core/src/main/java/co/paralleluniverse/common/reflection/GetAccessDeclaredField.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/reflection/GetAccessDeclaredField.java
@@ -1,0 +1,17 @@
+package co.paralleluniverse.common.reflection;
+
+import java.lang.reflect.Field;
+
+public class GetAccessDeclaredField extends GetDeclaredField {
+
+    public GetAccessDeclaredField(Class<?> clazz, String fieldName) {
+        super(clazz, fieldName);
+    }
+
+    @Override
+    public Field run() throws NoSuchFieldException {
+        Field field = super.run();
+        field.setAccessible(true);
+        return field;
+    }
+}

--- a/quasar-core/src/main/java/co/paralleluniverse/common/reflection/GetAccessDeclaredMethod.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/reflection/GetAccessDeclaredMethod.java
@@ -1,0 +1,17 @@
+package co.paralleluniverse.common.reflection;
+
+import java.lang.reflect.Method;
+
+public class GetAccessDeclaredMethod extends GetDeclaredMethod {
+
+    public GetAccessDeclaredMethod(Class<?> clazz, String methodName, Class<?>... args) {
+        super(clazz, methodName, args);
+    }
+
+    @Override
+    public Method run() throws NoSuchMethodException {
+        Method method = super.run();
+        method.setAccessible(true);
+        return method;
+    }
+}

--- a/quasar-core/src/main/java/co/paralleluniverse/common/reflection/GetDeclaredField.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/reflection/GetDeclaredField.java
@@ -1,0 +1,19 @@
+package co.paralleluniverse.common.reflection;
+
+import java.lang.reflect.Field;
+import java.security.PrivilegedExceptionAction;
+
+public class GetDeclaredField implements PrivilegedExceptionAction<Field> {
+    private final Class<?> clazz;
+    private final String fieldName;
+
+    public GetDeclaredField(Class<?> clazz, String fieldName) {
+        this.clazz = clazz;
+        this.fieldName = fieldName;
+    }
+
+    @Override
+    public Field run() throws NoSuchFieldException {
+        return clazz.getDeclaredField(fieldName);
+    }
+}

--- a/quasar-core/src/main/java/co/paralleluniverse/common/reflection/GetDeclaredMethod.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/reflection/GetDeclaredMethod.java
@@ -1,0 +1,21 @@
+package co.paralleluniverse.common.reflection;
+
+import java.lang.reflect.Method;
+import java.security.PrivilegedExceptionAction;
+
+public class GetDeclaredMethod implements PrivilegedExceptionAction<Method> {
+    private final Class<?> clazz;
+    private final String methodName;
+    private final Class<?>[] args;
+
+    public GetDeclaredMethod(Class<?> clazz, String methodName, Class<?>... args) {
+        this.clazz = clazz;
+        this.methodName = methodName;
+        this.args = args;
+    }
+
+    @Override
+    public Method run() throws NoSuchMethodException {
+        return clazz.getDeclaredMethod(methodName, args);
+    }
+}

--- a/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTraceClassContext.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTraceClassContext.java
@@ -12,11 +12,15 @@
  */
 package co.paralleluniverse.common.util;
 
+import java.security.PrivilegedAction;
+
+import static java.security.AccessController.doPrivileged;
+
 /**
  * @author pron
  */
 class ExtendedStackTraceClassContext extends ExtendedStackTrace {
-    private static final ClassContext classContextGenerator = new ClassContext();
+    private static final ClassContext classContextGenerator = doPrivileged(new CreateClassContext());
     private ExtendedStackTraceElement[] est;
     private final Class[] classContext;
 
@@ -82,6 +86,13 @@ class ExtendedStackTraceClassContext extends ExtendedStackTrace {
         @Override
         public Class[] getClassContext() {
             return super.getClassContext();
+        }
+    }
+
+    private static final class CreateClassContext implements PrivilegedAction<ClassContext> {
+        @Override
+        public ClassContext run() {
+            return new ClassContext();
         }
     }
 }

--- a/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTraceHotSpot.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTraceHotSpot.java
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
 import java.util.Iterator;
 
 import static co.paralleluniverse.common.util.Exceptions.rethrow;
@@ -243,6 +244,8 @@ class ExtendedStackTraceHotSpot extends ExtendedStackTrace {
             BACKTRACE_FIELD_OFFSET = doPrivileged(new GuessBacktraceFieldOffset());
 
             sanityCheck();
+        } catch (PrivilegedActionException e) {
+            throw new AssertionError(e.getCause());
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTraceHotSpot.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTraceHotSpot.java
@@ -12,16 +12,19 @@
  */
 package co.paralleluniverse.common.util;
 
+import co.paralleluniverse.common.reflection.GetAccessDeclaredField;
+import co.paralleluniverse.common.reflection.GetAccessDeclaredMethod;
+
 import java.lang.reflect.Constructor;
-// import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
+import java.security.PrivilegedAction;
 import java.util.Iterator;
 
-import static co.paralleluniverse.common.reflection.ReflectionUtil.accessible;
 import static co.paralleluniverse.common.util.Exceptions.rethrow;
+import static java.security.AccessController.doPrivileged;
 
 /**
  * This classes uses internal HotSpot data to retrieve a more detailed stacktrace from a {@link Throwable}.
@@ -224,20 +227,20 @@ class ExtendedStackTraceHotSpot extends ExtendedStackTrace {
 
     static {
         try {
-            final String javaVersion = System.getProperty("java.version");
+            final String javaVersion = doPrivileged(new GetProperty("java.version"));
             if (!javaVersion.startsWith("1.8") && !javaVersion.startsWith("8.") && !javaVersion.startsWith("1.9") && !javaVersion.startsWith("9."))
                 throw new IllegalStateException("UnsupportedJavaVersion");
-            if (!System.getProperty("java.vm.name").toLowerCase().contains("hotspot"))
+            if (!doPrivileged(new GetProperty("java.vm.name")).toLowerCase().contains("hotspot"))
                 throw new IllegalStateException("Not HotSpot");
             // the JVM blocks access to Throwable.backtrace via reflection
             // backtrace = ReflectionUtil.accessible(Throwable.class.getDeclaredField("backtrace"));
-            getStackTraceDepth = accessible(Throwable.class.getDeclaredMethod("getStackTraceDepth"));
-            getStackTraceElement = accessible(Throwable.class.getDeclaredMethod("getStackTraceElement", int.class));
-            methodSlot = accessible(Method.class.getDeclaredField("slot"));
-            ctorSlot = accessible(Constructor.class.getDeclaredField("slot"));
-            fieldSlot = accessible(Field.class.getDeclaredField("slot"));
+            getStackTraceDepth = doPrivileged(new GetAccessDeclaredMethod(Throwable.class, "getStackTraceDepth"));
+            getStackTraceElement = doPrivileged(new GetAccessDeclaredMethod(Throwable.class, "getStackTraceElement", int.class));
+            methodSlot = doPrivileged(new GetAccessDeclaredField(Method.class, "slot"));
+            ctorSlot = doPrivileged(new GetAccessDeclaredField(Constructor.class, "slot"));
+            fieldSlot = doPrivileged(new GetAccessDeclaredField(Field.class, "slot"));
 
-            BACKTRACE_FIELD_OFFSET = guessBacktraceFieldOffset();
+            BACKTRACE_FIELD_OFFSET = doPrivileged(new GuessBacktraceFieldOffset());
 
             sanityCheck();
         } catch (Exception e) {
@@ -245,24 +248,40 @@ class ExtendedStackTraceHotSpot extends ExtendedStackTrace {
         }
     }
 
-    private static long guessBacktraceFieldOffset() {
-        Field[] fs = Throwable.class.getDeclaredFields();
-        Field second = null;
-        for (Field f : fs) {
-            if (getSlot(f) == 2) {
-                second = f;
-                break;
-            }
+    private static final class GetProperty implements PrivilegedAction<String> {
+        private final String name;
+
+        GetProperty(String name) {
+            this.name = name;
         }
-        if (second == null)
-            throw new IllegalStateException();
-        long secondOffest = UNSAFE.objectFieldOffset(second);
-        if (secondOffest == 16)
-            return 12; // compressed oops
-        if (secondOffest == 24)
-            return 16; // no compressed oops
-        else
-            throw new IllegalStateException("secondOffset: " + secondOffest); // unfamiliar
+
+        @Override
+        public String run() {
+            return System.getProperty(name);
+        }
+    }
+
+    private static final class GuessBacktraceFieldOffset implements PrivilegedAction<Long> {
+        @Override
+        public Long run() {
+            Field[] fs = Throwable.class.getDeclaredFields();
+            Field second = null;
+            for (Field f : fs) {
+                if (getSlot(f) == 2) {
+                    second = f;
+                    break;
+                }
+            }
+            if (second == null)
+                throw new IllegalStateException();
+            long secondOffest = UNSAFE.objectFieldOffset(second);
+            if (secondOffest == 16)
+                return 12L; // compressed oops
+            if (secondOffest == 24)
+                return 16L; // no compressed oops
+            else
+                throw new IllegalStateException("secondOffset: " + secondOffest); // unfamiliar
+        }
     }
 
     private static void sanityCheck() {

--- a/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/ConcurrentSkipListPriorityQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/ConcurrentSkipListPriorityQueue.java
@@ -23,6 +23,8 @@ package co.paralleluniverse.concurrent.util;
 
 import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
+
+import java.security.PrivilegedActionException;
 import java.util.*;
 
 import static java.security.AccessController.doPrivileged;
@@ -432,6 +434,8 @@ public class ConcurrentSkipListPriorityQueue<E> extends AbstractQueue<E>
                 Class k = Node.class;
                 valueOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "value")));
                 nextOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "next")));
+            } catch (PrivilegedActionException e) {
+                throw new Error(e.getCause());
             } catch (Exception e) {
                 throw new Error(e);
             }
@@ -511,6 +515,8 @@ public class ConcurrentSkipListPriorityQueue<E> extends AbstractQueue<E>
                 UNSAFE = UtilUnsafe.getUnsafe();
                 Class k = Index.class;
                 rightOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "right")));
+            } catch (PrivilegedActionException e) {
+                throw new Error(e.getCause());
             } catch (Exception e) {
                 throw new Error(e);
             }
@@ -1574,6 +1580,8 @@ public class ConcurrentSkipListPriorityQueue<E> extends AbstractQueue<E>
             UNSAFE = UtilUnsafe.getUnsafe();
             Class k = ConcurrentSkipListPriorityQueue.class;
             headOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "head")));
+        } catch (PrivilegedActionException e) {
+            throw new Error(e.getCause());
         } catch (Exception e) {
             throw new Error(e);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/ConcurrentSkipListPriorityQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/ConcurrentSkipListPriorityQueue.java
@@ -21,8 +21,11 @@
  */
 package co.paralleluniverse.concurrent.util;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import java.util.*;
+
+import static java.security.AccessController.doPrivileged;
 
 public class ConcurrentSkipListPriorityQueue<E> extends AbstractQueue<E>
         implements Cloneable,
@@ -427,8 +430,8 @@ public class ConcurrentSkipListPriorityQueue<E> extends AbstractQueue<E>
             try {
                 UNSAFE = UtilUnsafe.getUnsafe();
                 Class k = Node.class;
-                valueOffset = UNSAFE.objectFieldOffset(k.getDeclaredField("value"));
-                nextOffset = UNSAFE.objectFieldOffset(k.getDeclaredField("next"));
+                valueOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "value")));
+                nextOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "next")));
             } catch (Exception e) {
                 throw new Error(e);
             }
@@ -507,7 +510,7 @@ public class ConcurrentSkipListPriorityQueue<E> extends AbstractQueue<E>
             try {
                 UNSAFE = UtilUnsafe.getUnsafe();
                 Class k = Index.class;
-                rightOffset = UNSAFE.objectFieldOffset(k.getDeclaredField("right"));
+                rightOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "right")));
             } catch (Exception e) {
                 throw new Error(e);
             }
@@ -1570,7 +1573,7 @@ public class ConcurrentSkipListPriorityQueue<E> extends AbstractQueue<E>
         try {
             UNSAFE = UtilUnsafe.getUnsafe();
             Class k = ConcurrentSkipListPriorityQueue.class;
-            headOffset = UNSAFE.objectFieldOffset(k.getDeclaredField("head"));
+            headOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "head")));
         } catch (Exception e) {
             throw new Error(e);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/OwnedSynchronizer2.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/OwnedSynchronizer2.java
@@ -12,11 +12,14 @@
  */
 package co.paralleluniverse.concurrent.util;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import sun.misc.Unsafe;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -104,7 +107,7 @@ class OwnedSynchronizer2 extends OwnedSynchronizer {
 
     static {
         try {
-            waiterOffset = UNSAFE.objectFieldOffset(OwnedSynchronizer2.class.getDeclaredField("waiter"));
+            waiterOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(OwnedSynchronizer2.class, "waiter")));
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/OwnedSynchronizer2.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/OwnedSynchronizer2.java
@@ -14,6 +14,7 @@ package co.paralleluniverse.concurrent.util;
 
 import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
+import java.security.PrivilegedActionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
@@ -108,6 +109,8 @@ class OwnedSynchronizer2 extends OwnedSynchronizer {
     static {
         try {
             waiterOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(OwnedSynchronizer2.class, "waiter")));
+        } catch (PrivilegedActionException ex) {
+            throw new Error(ex.getCause());
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/ThreadAccess.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/ThreadAccess.java
@@ -60,8 +60,8 @@ public class ThreadAccess {
                 _inheritedAccessControlContextOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Thread.class, "inheritedAccessControlContext")));
             } catch (PrivilegedActionException e) {
                 Throwable t = e.getCause();
-                if (!(t instanceof NoSuchMethodException)) {
-                    throw (t instanceof RuntimeException) ? (RuntimeException) t : new RuntimeException(t);
+                if (!(t instanceof NoSuchFieldException)) {
+                    throw new RuntimeException(t);
                 }
             }
             inheritedAccessControlContextOffset = _inheritedAccessControlContextOffset;
@@ -78,6 +78,8 @@ public class ThreadAccess {
             threadLocalMapEntryClass = Class.forName("java.lang.ThreadLocal$ThreadLocalMap$Entry");
             threadLocalMapEntryConstructor = doPrivileged(new GetAccessDeclaredConstructor<>(threadLocalMapEntryClass, ThreadLocal.class, Object.class));
             threadLocalMapEntryValueField = doPrivileged(new GetAccessDeclaredField(threadLocalMapEntryClass, "value"));
+        } catch (PrivilegedActionException ex) {
+            throw new AssertionError(ex.getCause());
         } catch (Exception ex) {
             throw new AssertionError(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/ThreadAccess.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/ThreadAccess.java
@@ -13,6 +13,9 @@
  */
 package co.paralleluniverse.concurrent.util;
 
+import co.paralleluniverse.common.reflection.GetAccessDeclaredConstructor;
+import co.paralleluniverse.common.reflection.GetAccessDeclaredField;
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.*;
 import sun.misc.*;
 
@@ -20,6 +23,8 @@ import java.lang.ref.*;
 import java.lang.reflect.*;
 import java.security.*;
 import java.util.*;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -32,50 +37,47 @@ public class ThreadAccess {
     private static final long inheritableThreadLocalsOffset;
     private static final long contextClassLoaderOffset;
     private static final long inheritedAccessControlContextOffset;
-    private static final Class threadLocalMapClass;
-    private static final Constructor threadLocalMapConstructor;
-    private static final Constructor threadLocalMapInheritedConstructor;
+    private static final Class<?> threadLocalMapClass;
+    private static final Constructor<?> threadLocalMapConstructor;
+    private static final Constructor<?> threadLocalMapInheritedConstructor;
 //    private static final Method threadLocalMapSet;
     private static final Field threadLocalMapTableField;
     private static final Field threadLocalMapSizeField;
     private static final Field threadLocalMapThresholdField;
-    private static final Class threadLocalMapEntryClass;
-    private static final Constructor threadLocalMapEntryConstructor;
+    private static final Class<?> threadLocalMapEntryClass;
+    private static final Constructor<?> threadLocalMapEntryConstructor;
     private static final Field threadLocalMapEntryValueField;
 
     static {
         try {
-            targetOffset = UNSAFE.objectFieldOffset(Thread.class.getDeclaredField("target"));
-            threadLocalsOffset = UNSAFE.objectFieldOffset(Thread.class.getDeclaredField("threadLocals"));
-            inheritableThreadLocalsOffset = UNSAFE.objectFieldOffset(Thread.class.getDeclaredField("inheritableThreadLocals"));
-            contextClassLoaderOffset = UNSAFE.objectFieldOffset(Thread.class.getDeclaredField("contextClassLoader"));
+            targetOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Thread.class, "target")));
+            threadLocalsOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Thread.class, "threadLocals")));
+            inheritableThreadLocalsOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Thread.class, "inheritableThreadLocals")));
+            contextClassLoaderOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Thread.class, "contextClassLoader")));
 
             long _inheritedAccessControlContextOffset = -1;
             try {
-                _inheritedAccessControlContextOffset = UNSAFE.objectFieldOffset(Thread.class.getDeclaredField("inheritedAccessControlContext"));
-            } catch (NoSuchFieldException e) {
+                _inheritedAccessControlContextOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Thread.class, "inheritedAccessControlContext")));
+            } catch (PrivilegedActionException e) {
+                Throwable t = e.getCause();
+                if (!(t instanceof NoSuchMethodException)) {
+                    throw (t instanceof RuntimeException) ? (RuntimeException) t : new RuntimeException(t);
+                }
             }
             inheritedAccessControlContextOffset = _inheritedAccessControlContextOffset;
 
             threadLocalMapClass = Class.forName("java.lang.ThreadLocal$ThreadLocalMap");
-            threadLocalMapConstructor = threadLocalMapClass.getDeclaredConstructor(ThreadLocal.class, Object.class);
-            threadLocalMapConstructor.setAccessible(true);
-            threadLocalMapInheritedConstructor = threadLocalMapClass.getDeclaredConstructor(threadLocalMapClass);
-            threadLocalMapInheritedConstructor.setAccessible(true);
+            threadLocalMapConstructor = doPrivileged(new GetAccessDeclaredConstructor<>(threadLocalMapClass, ThreadLocal.class, Object.class));
+            threadLocalMapInheritedConstructor = doPrivileged(new GetAccessDeclaredConstructor<>(threadLocalMapClass, threadLocalMapClass));
 //            threadLocalMapSet = threadLocalMapClass.getDeclaredMethod("set", ThreadLocal.class, Object.class);
 //            threadLocalMapSet.setAccessible(true);
-            threadLocalMapTableField = threadLocalMapClass.getDeclaredField("table");
-            threadLocalMapTableField.setAccessible(true);
-            threadLocalMapSizeField = threadLocalMapClass.getDeclaredField("size");
-            threadLocalMapSizeField.setAccessible(true);
-            threadLocalMapThresholdField = threadLocalMapClass.getDeclaredField("threshold");
-            threadLocalMapThresholdField.setAccessible(true);
+            threadLocalMapTableField = doPrivileged(new GetAccessDeclaredField(threadLocalMapClass, "table"));
+            threadLocalMapSizeField = doPrivileged(new GetAccessDeclaredField(threadLocalMapClass, "size"));
+            threadLocalMapThresholdField = doPrivileged(new GetAccessDeclaredField(threadLocalMapClass, "threshold"));
 
             threadLocalMapEntryClass = Class.forName("java.lang.ThreadLocal$ThreadLocalMap$Entry");
-            threadLocalMapEntryConstructor = threadLocalMapEntryClass.getDeclaredConstructor(ThreadLocal.class, Object.class);
-            threadLocalMapEntryConstructor.setAccessible(true);
-            threadLocalMapEntryValueField = threadLocalMapEntryClass.getDeclaredField("value");
-            threadLocalMapEntryValueField.setAccessible(true);
+            threadLocalMapEntryConstructor = doPrivileged(new GetAccessDeclaredConstructor<>(threadLocalMapEntryClass, ThreadLocal.class, Object.class));
+            threadLocalMapEntryValueField = doPrivileged(new GetAccessDeclaredField(threadLocalMapEntryClass, "value"));
         } catch (Exception ex) {
             throw new AssertionError(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/ThreadUtil.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/ThreadUtil.java
@@ -12,10 +12,14 @@
  */
 package co.paralleluniverse.concurrent.util;
 
+import co.paralleluniverse.common.reflection.GetAccessDeclaredField;
+
 import java.lang.ref.Reference;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.util.Map;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -100,19 +104,14 @@ public final class ThreadUtil {
 
     static {
         try {
-            threadLocalsField = Thread.class.getDeclaredField("threadLocals");
-            threadLocalsField.setAccessible(true);
-
-            inheritableThreadLocalsField = Thread.class.getDeclaredField("inheritableThreadLocals");
-            inheritableThreadLocalsField.setAccessible(true);
+            threadLocalsField = doPrivileged(new GetAccessDeclaredField(Thread.class, "threadLocals"));
+            inheritableThreadLocalsField = doPrivileged(new GetAccessDeclaredField(Thread.class, "inheritableThreadLocals"));
 
             Class threadLocalMapClass = Class.forName("java.lang.ThreadLocal$ThreadLocalMap");
-            threadLocalMapTableField = threadLocalMapClass.getDeclaredField("table");
-            threadLocalMapTableField.setAccessible(true);
+            threadLocalMapTableField = doPrivileged(new GetAccessDeclaredField(threadLocalMapClass, "table"));
 
             Class threadLocalMapEntryClass = Class.forName("java.lang.ThreadLocal$ThreadLocalMap$Entry");
-            threadLocalMapEntryValueField = threadLocalMapEntryClass.getDeclaredField("value");
-            threadLocalMapEntryValueField.setAccessible(true);
+            threadLocalMapEntryValueField = doPrivileged(new GetAccessDeclaredField(threadLocalMapEntryClass, "value"));
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/ThreadUtil.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/ThreadUtil.java
@@ -17,6 +17,7 @@ import co.paralleluniverse.common.reflection.GetAccessDeclaredField;
 import java.lang.ref.Reference;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.security.PrivilegedActionException;
 import java.util.Map;
 
 import static java.security.AccessController.doPrivileged;
@@ -112,6 +113,8 @@ public final class ThreadUtil {
 
             Class threadLocalMapEntryClass = Class.forName("java.lang.ThreadLocal$ThreadLocalMap$Entry");
             threadLocalMapEntryValueField = doPrivileged(new GetAccessDeclaredField(threadLocalMapEntryClass, "value"));
+        } catch (PrivilegedActionException e) {
+            throw new AssertionError(e.getCause());
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
@@ -47,6 +47,7 @@ import java.lang.reflect.Method;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -1864,6 +1865,8 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
     static {
         try {
             stateOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Fiber.class, "state")));
+        } catch (PrivilegedActionException ex) {
+            throw new AssertionError(ex.getCause());
         } catch (Exception ex) {
             throw new AssertionError(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
@@ -16,6 +16,7 @@ package co.paralleluniverse.fibers;
 import co.paralleluniverse.common.monitoring.FlightRecorder;
 import co.paralleluniverse.common.monitoring.FlightRecorderMessage;
 import co.paralleluniverse.common.reflection.ASMUtil;
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.Debug;
 import co.paralleluniverse.common.util.Exceptions;
 import co.paralleluniverse.common.util.ExtendedStackTrace;
@@ -37,6 +38,7 @@ import co.paralleluniverse.strands.SuspendableCallable;
 import co.paralleluniverse.strands.SuspendableRunnable;
 import co.paralleluniverse.strands.SuspendableUtils.VoidSuspendableCallable;
 import static co.paralleluniverse.strands.SuspendableUtils.runnableToCallable;
+import static java.security.AccessController.doPrivileged;
 import co.paralleluniverse.strands.dataflow.Val;
 import java.io.PrintWriter;
 import java.io.Serializable;
@@ -44,6 +46,7 @@ import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.security.AccessControlContext;
 import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -56,7 +59,6 @@ import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
-// import java.lang.reflect.Executable;
 import java.lang.reflect.Member;
 
 /**
@@ -1805,30 +1807,43 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
     private static boolean isInstrumented(Class clazz) {
         boolean res = clazz.isAnnotationPresent(Instrumented.class);
         if (!res)
-            res = isInstrumented0(clazz); // a second chance
+            res = doPrivileged(new CheckInstrumented(clazz)); // a second chance
         return res;
     }
 
-    private static boolean isInstrumented0(Class clazz) {
-        // Sometimes, a child class does not implement any suspendable methods AND is loaded before its superclass (that does). Test for that:
-        Class superclazz = clazz.getSuperclass();
-        if (superclazz != null) {
-            if (superclazz.isAnnotationPresent(Instrumented.class)) {
-                // make sure the child class doesn't have any suspendable methods
-                Method[] ms = clazz.getDeclaredMethods();
-                for (Method m : ms) {
-                    for (Class et : m.getExceptionTypes()) {
-                        if (et.equals(SuspendExecution.class))
+    private static final class CheckInstrumented implements PrivilegedAction<Boolean> {
+        private final Class<?> clazz;
+
+        CheckInstrumented(Class<?> clazz) {
+            this.clazz = clazz;
+        }
+
+        @Override
+        public Boolean run() {
+            return isInstrumented0(clazz);
+        }
+
+        private static boolean isInstrumented0(Class clazz) {
+            // Sometimes, a child class does not implement any suspendable methods AND is loaded before its superclass (that does). Test for that:
+            Class superclazz = clazz.getSuperclass();
+            if (superclazz != null) {
+                if (superclazz.isAnnotationPresent(Instrumented.class)) {
+                    // make sure the child class doesn't have any suspendable methods
+                    Method[] ms = clazz.getDeclaredMethods();
+                    for (Method m : ms) {
+                        for (Class et : m.getExceptionTypes()) {
+                            if (et.equals(SuspendExecution.class))
+                                return false;
+                        }
+                        if (m.isAnnotationPresent(Suspendable.class))
                             return false;
                     }
-                    if (m.isAnnotationPresent(Suspendable.class))
-                        return false;
-                }
-                return true;
+                    return true;
+                } else
+                    return isInstrumented0(superclazz);
             } else
-                return isInstrumented0(superclazz);
-        } else
-            return false;
+                return false;
+        }
     }
 
     @VisibleForTesting
@@ -1848,7 +1863,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
 
     static {
         try {
-            stateOffset = UNSAFE.objectFieldOffset(Fiber.class.getDeclaredField("state"));
+            stateOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Fiber.class, "state")));
         } catch (Exception ex) {
             throw new AssertionError(ex);
         }
@@ -2153,7 +2168,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
                 final Registration reg = kryo.readClass(input);
                 if (reg == null)
                     return null;
-                f = (Fiber) new FieldSerializer(kryo, reg.getType()).read(kryo, input, reg.getType());
+                f = (Fiber) new FieldSerializer<>(kryo, reg.getType()).read(kryo, input, reg.getType());
 
                 if (!f.noLocals) {
                     f.fiberLocals = ThreadAccess.getThreadLocals(currentThread);

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/RunnableFiberTask.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/RunnableFiberTask.java
@@ -19,11 +19,10 @@ import co.paralleluniverse.common.util.Debug;
 import co.paralleluniverse.common.util.Exceptions;
 import co.paralleluniverse.common.util.SystemProperties;
 import co.paralleluniverse.common.util.UtilUnsafe;
-import static co.paralleluniverse.fibers.FiberTask.*;
 import static java.security.AccessController.doPrivileged;
-
 import co.paralleluniverse.fibers.instrument.DontInstrument;
 import co.paralleluniverse.strands.SettableFuture;
+import java.security.PrivilegedActionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -357,6 +356,8 @@ class RunnableFiberTask<V> implements Runnable, FiberTask {
     static {
         try {
             stateOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(RunnableFiberTask.class, "state")));
+        } catch (PrivilegedActionException ex) {
+            throw new AssertionError(ex.getCause());
         } catch (Exception ex) {
             throw new AssertionError(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/RunnableFiberTask.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/RunnableFiberTask.java
@@ -14,11 +14,14 @@ package co.paralleluniverse.fibers;
 
 import co.paralleluniverse.common.monitoring.FlightRecorder;
 import co.paralleluniverse.common.monitoring.FlightRecorderMessage;
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.Debug;
 import co.paralleluniverse.common.util.Exceptions;
 import co.paralleluniverse.common.util.SystemProperties;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import static co.paralleluniverse.fibers.FiberTask.*;
+import static java.security.AccessController.doPrivileged;
+
 import co.paralleluniverse.fibers.instrument.DontInstrument;
 import co.paralleluniverse.strands.SettableFuture;
 import java.util.concurrent.ExecutionException;
@@ -353,7 +356,7 @@ class RunnableFiberTask<V> implements Runnable, FiberTask {
 
     static {
         try {
-            stateOffset = UNSAFE.objectFieldOffset(RunnableFiberTask.class.getDeclaredField("state"));
+            stateOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(RunnableFiberTask.class, "state")));
         } catch (Exception ex) {
             throw new AssertionError(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/OldSuspendablesScanner.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/OldSuspendablesScanner.java
@@ -14,8 +14,11 @@
 package co.paralleluniverse.fibers.instrument;
 
 import co.paralleluniverse.common.reflection.ASMUtil;
+import co.paralleluniverse.common.reflection.GetDeclaredMethod;
 import co.paralleluniverse.fibers.Suspendable;
 import static co.paralleluniverse.common.reflection.ASMUtil.*;
+import static java.security.AccessController.doPrivileged;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -24,6 +27,7 @@ import java.io.PrintStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.security.PrivilegedActionException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -291,9 +295,13 @@ public class OldSuspendablesScanner extends Task {
 
         if (!cls.equals(method.getDeclaringClass())) {
             try {
-                cls.getDeclaredMethod(method.getName(), method.getParameterTypes());
+                doPrivileged(new GetDeclaredMethod(cls, method.getName(), method.getParameterTypes()));
                 results.add(cls.getName() + '.' + method.getName());
-            } catch (NoSuchMethodException e) {
+            } catch (PrivilegedActionException e) {
+                Throwable t = e.getCause();
+                if (!(t instanceof NoSuchMethodException)) {
+                    throw (t instanceof RuntimeException) ? (RuntimeException) t : new RuntimeException(t);
+                }
             }
         }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/OldSuspendablesScanner.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/OldSuspendablesScanner.java
@@ -300,7 +300,7 @@ public class OldSuspendablesScanner extends Task {
             } catch (PrivilegedActionException e) {
                 Throwable t = e.getCause();
                 if (!(t instanceof NoSuchMethodException)) {
-                    throw (t instanceof RuntimeException) ? (RuntimeException) t : new RuntimeException(t);
+                    throw new RuntimeException(t);
                 }
             }
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarURLClassLoader.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarURLClassLoader.java
@@ -26,7 +26,10 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLStreamHandlerFactory;
 import java.nio.ByteBuffer;
-import java.security.*;
+import java.security.AccessControlContext;
+import java.security.CodeSigner;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.security.cert.Certificate;
 import java.util.Arrays;
 import java.util.jar.Manifest;
@@ -209,8 +212,7 @@ public class QuasarURLClassLoader extends URLClassLoader {
             accField = doPrivileged(new GetAccessDeclaredField(URLClassLoader.class, "acc"));
             defineClassMethod = doPrivileged(new GetAccessDeclaredMethod(URLClassLoader.class, "defineClass", String.class, Resource.class));
         } catch (PrivilegedActionException e) {
-            Throwable t = e.getCause();
-            throw (t instanceof RuntimeException) ? (RuntimeException) t : new RuntimeException(t);
+            throw new RuntimeException(e.getCause());
         }
     }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarURLClassLoader.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarURLClassLoader.java
@@ -13,6 +13,8 @@
  */
 package co.paralleluniverse.fibers.instrument;
 
+import co.paralleluniverse.common.reflection.GetAccessDeclaredField;
+import co.paralleluniverse.common.reflection.GetAccessDeclaredMethod;
 import com.google.common.io.ByteStreams;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -24,15 +26,14 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLStreamHandlerFactory;
 import java.nio.ByteBuffer;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.CodeSigner;
-import java.security.PrivilegedExceptionAction;
+import java.security.*;
 import java.security.cert.Certificate;
 import java.util.Arrays;
 import java.util.jar.Manifest;
 import sun.misc.Resource;
 import sun.misc.URLClassPath;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -79,7 +80,7 @@ public class QuasarURLClassLoader extends URLClassLoader {
     protected Class<?> findClass(final String name)
             throws ClassNotFoundException {
         try {
-            return AccessController.doPrivileged(
+            return doPrivileged(
                     new PrivilegedExceptionAction<Class>() {
                         @Override
                         public Class run() throws ClassNotFoundException {
@@ -204,14 +205,12 @@ public class QuasarURLClassLoader extends URLClassLoader {
 
     static {
         try {
-            ucpField = URLClassLoader.class.getDeclaredField("ucp");
-            accField = URLClassLoader.class.getDeclaredField("acc");
-            defineClassMethod = URLClassLoader.class.getDeclaredMethod("defineClass", String.class, Resource.class);
-            ucpField.setAccessible(true);
-            accField.setAccessible(true);
-            defineClassMethod.setAccessible(true);
-        } catch (NoSuchFieldException | NoSuchMethodException | SecurityException e) {
-            throw new RuntimeException(e);
+            ucpField = doPrivileged(new GetAccessDeclaredField(URLClassLoader.class, "ucp"));
+            accField = doPrivileged(new GetAccessDeclaredField(URLClassLoader.class, "acc"));
+            defineClassMethod = doPrivileged(new GetAccessDeclaredMethod(URLClassLoader.class, "defineClass", String.class, Resource.class));
+        } catch (PrivilegedActionException e) {
+            Throwable t = e.getCause();
+            throw (t instanceof RuntimeException) ? (RuntimeException) t : new RuntimeException(t);
         }
     }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarURLClassLoaderHelper.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarURLClassLoaderHelper.java
@@ -25,7 +25,11 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.ByteBuffer;
-import java.security.*;
+import java.security.AccessControlContext;
+import java.security.AccessController;
+import java.security.CodeSigner;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.security.cert.Certificate;
 import java.util.Arrays;
 import java.util.jar.Manifest;
@@ -197,8 +201,7 @@ public final class QuasarURLClassLoaderHelper {
             accField = doPrivileged(new GetAccessDeclaredField(URLClassLoader.class, "acc"));
             defineClassMethod = doPrivileged(new GetAccessDeclaredMethod(URLClassLoader.class, "defineClass", String.class, Resource.class));
         } catch (PrivilegedActionException e) {
-            Throwable t = e.getCause();
-            throw (t instanceof RuntimeException) ? (RuntimeException) t : new RuntimeException(t);
+            throw new RuntimeException(e.getCause());
         }
     }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarURLClassLoaderHelper.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarURLClassLoaderHelper.java
@@ -13,6 +13,8 @@
  */
 package co.paralleluniverse.fibers.instrument;
 
+import co.paralleluniverse.common.reflection.GetAccessDeclaredField;
+import co.paralleluniverse.common.reflection.GetAccessDeclaredMethod;
 import com.google.common.io.ByteStreams;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -23,15 +25,14 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.ByteBuffer;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.CodeSigner;
-import java.security.PrivilegedExceptionAction;
+import java.security.*;
 import java.security.cert.Certificate;
 import java.util.Arrays;
 import java.util.jar.Manifest;
 import sun.misc.Resource;
 import sun.misc.URLClassPath;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -192,14 +193,12 @@ public final class QuasarURLClassLoaderHelper {
 
     static {
         try {
-            ucpField = URLClassLoader.class.getDeclaredField("ucp");
-            accField = URLClassLoader.class.getDeclaredField("acc");
-            defineClassMethod = URLClassLoader.class.getDeclaredMethod("defineClass", String.class, Resource.class);
-            ucpField.setAccessible(true);
-            accField.setAccessible(true);
-            defineClassMethod.setAccessible(true);
-        } catch (NoSuchFieldException | NoSuchMethodException | SecurityException e) {
-            throw new RuntimeException(e);
+            ucpField = doPrivileged(new GetAccessDeclaredField(URLClassLoader.class, "ucp"));
+            accField = doPrivileged(new GetAccessDeclaredField(URLClassLoader.class, "acc"));
+            defineClassMethod = doPrivileged(new GetAccessDeclaredMethod(URLClassLoader.class, "defineClass", String.class, Resource.class));
+        } catch (PrivilegedActionException e) {
+            Throwable t = e.getCause();
+            throw (t instanceof RuntimeException) ? (RuntimeException) t : new RuntimeException(t);
         }
     }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/CollectionsSetFromMapSerializer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/CollectionsSetFromMapSerializer.java
@@ -12,6 +12,7 @@
  */
 package co.paralleluniverse.io.serialization.kryo;
 
+import co.paralleluniverse.common.reflection.GetAccessDeclaredField;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
@@ -21,6 +22,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -33,10 +36,8 @@ class CollectionsSetFromMapSerializer extends Serializer<Set> {
     static {
         try {
             final Class<?> cl = Collections.newSetFromMap(new HashMap()).getClass();
-            mf = cl.getDeclaredField("m");
-            mf.setAccessible(true);
-            sf = cl.getDeclaredField("s");
-            sf.setAccessible(true);
+            mf = doPrivileged(new GetAccessDeclaredField(cl, "m"));
+            sf = doPrivileged(new GetAccessDeclaredField(cl, "s"));
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/CollectionsSetFromMapSerializer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/CollectionsSetFromMapSerializer.java
@@ -18,6 +18,7 @@ import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import java.lang.reflect.Field;
+import java.security.PrivilegedActionException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -38,6 +39,8 @@ class CollectionsSetFromMapSerializer extends Serializer<Set> {
             final Class<?> cl = Collections.newSetFromMap(new HashMap()).getClass();
             mf = doPrivileged(new GetAccessDeclaredField(cl, "m"));
             sf = doPrivileged(new GetAccessDeclaredField(cl, "s"));
+        } catch (PrivilegedActionException e) {
+            throw new AssertionError(e.getCause());
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/ReplacableObjectSerializer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/ReplacableObjectSerializer.java
@@ -12,6 +12,7 @@
  */
 package co.paralleluniverse.io.serialization.kryo;
 
+import co.paralleluniverse.common.reflection.GetAccessDeclaredMethod;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
@@ -20,6 +21,9 @@ import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.security.PrivilegedActionException;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -40,6 +44,18 @@ class ReplacableObjectSerializer extends FieldSerializer<Object> {
         return getReplacement(super.read(kryo, input, type), "readResolve");
     }
 
+    private static Method getDeclaredMethod(Class<?> clazz, String methodName) throws NoSuchMethodException {
+        try {
+            return doPrivileged(new GetAccessDeclaredMethod(clazz, methodName));
+        } catch (PrivilegedActionException e) {
+            Throwable t = e.getCause();
+            if (t instanceof NoSuchMethodException) {
+                throw (NoSuchMethodException) t;
+            }
+            throw (t instanceof RuntimeException) ? (RuntimeException) t : new RuntimeException(t);
+        }
+    }
+
     private static Object getReplacement(Object obj, final String replaceMethodName) {
         try {
             Class clazz = obj.getClass();
@@ -48,14 +64,14 @@ class ReplacableObjectSerializer extends FieldSerializer<Object> {
 
             Method m = null;
             try {
-                m = clazz.getDeclaredMethod(replaceMethodName);
+                m = getDeclaredMethod(clazz, replaceMethodName);
             } catch (NoSuchMethodException ex) {
                 Class ancestor = clazz.getSuperclass();
                 while (ancestor != null) {
                     if (!Serializable.class.isAssignableFrom(ancestor))
                         return obj;
                     try {
-                        m = ancestor.getDeclaredMethod(replaceMethodName);
+                        m = getDeclaredMethod(ancestor, replaceMethodName);
                         if (!Modifier.isPublic(m.getModifiers()) && !Modifier.isProtected(m.getModifiers()))
                             return obj;
                         break;
@@ -66,9 +82,7 @@ class ReplacableObjectSerializer extends FieldSerializer<Object> {
             }
             if (m == null)
                 return obj;
-            m.setAccessible(true);
-            Object replacement = m.invoke(obj);
-            return replacement;
+            return m.invoke(obj);
         } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
             if (ex instanceof InvocationTargetException)
                 ((InvocationTargetException) ex).getTargetException().printStackTrace();

--- a/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/ReplacableObjectSerializer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/ReplacableObjectSerializer.java
@@ -52,7 +52,7 @@ class ReplacableObjectSerializer extends FieldSerializer<Object> {
             if (t instanceof NoSuchMethodException) {
                 throw (NoSuchMethodException) t;
             }
-            throw (t instanceof RuntimeException) ? (RuntimeException) t : new RuntimeException(t);
+            throw new RuntimeException(t);
         }
     }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/ReplaceableObjectKryo.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/ReplaceableObjectKryo.java
@@ -12,6 +12,7 @@
  */
 package co.paralleluniverse.io.serialization.kryo;
 
+import co.paralleluniverse.common.reflection.GetAccessDeclaredMethod;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Registration;
 import com.esotericsoftware.kryo.Serializer;
@@ -22,6 +23,9 @@ import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.security.PrivilegedActionException;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  * A subclass of {@link Kryo} that respects {@link Serializable java.io.Serializable}'s {@code writeReplace} and {@code readResolve}.
@@ -134,20 +138,32 @@ public class ReplaceableObjectKryo extends Kryo {
         return replaceMethodsCache.get(clazz);
     }
 
+    private static Method getDeclaredMethod(Class<?> clazz, String methodName, Class<?>... args) throws NoSuchMethodException {
+        try {
+            return doPrivileged(new GetAccessDeclaredMethod(clazz, methodName, args));
+        } catch (PrivilegedActionException e) {
+            Throwable t = e.getCause();
+            if (t instanceof NoSuchMethodException) {
+                throw (NoSuchMethodException) t;
+            }
+            throw (t instanceof RuntimeException) ? (RuntimeException) t : new RuntimeException(t);
+        }
+    }
+
     private static Method getMethodByReflection(Class clazz, final String methodName, Class<?>... paramTypes) throws SecurityException {
         if (!Serializable.class.isAssignableFrom(clazz))
             return null;
 
         Method m = null;
         try {
-            m = clazz.getDeclaredMethod(methodName, paramTypes);
+            m = getDeclaredMethod(clazz, methodName, paramTypes);
         } catch (NoSuchMethodException ex) {
             Class ancestor = clazz.getSuperclass();
             while (ancestor != null) {
                 if (!Serializable.class.isAssignableFrom(ancestor))
                     return null;
                 try {
-                    m = ancestor.getDeclaredMethod(methodName, paramTypes);
+                    m = getDeclaredMethod(ancestor, methodName, paramTypes);
                     if (!Modifier.isPublic(m.getModifiers()) && !Modifier.isProtected(m.getModifiers()))
                         return null;
                     break;
@@ -156,8 +172,6 @@ public class ReplaceableObjectKryo extends Kryo {
                 }
             }
         }
-        if (m != null)
-            m.setAccessible(true);
         return m;
     }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/ReplaceableObjectKryo.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/ReplaceableObjectKryo.java
@@ -146,7 +146,7 @@ public class ReplaceableObjectKryo extends Kryo {
             if (t instanceof NoSuchMethodException) {
                 throw (NoSuchMethodException) t;
             }
-            throw (t instanceof RuntimeException) ? (RuntimeException) t : new RuntimeException(t);
+            throw new RuntimeException(t);
         }
     }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/AbstractFuture.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/AbstractFuture.java
@@ -17,6 +17,7 @@ import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import co.paralleluniverse.fibers.SuspendExecution;
 import co.paralleluniverse.fibers.Suspendable;
+import java.security.PrivilegedActionException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -153,6 +154,8 @@ public class AbstractFuture<V> implements Future<V> {
     static {
         try {
             settingOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(AbstractFuture.class, "setting")));
+        } catch (PrivilegedActionException ex) {
+            throw new AssertionError(ex.getCause());
         } catch (Exception ex) {
             throw new AssertionError(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/AbstractFuture.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/AbstractFuture.java
@@ -13,6 +13,7 @@
  */
 package co.paralleluniverse.strands;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import co.paralleluniverse.fibers.SuspendExecution;
 import co.paralleluniverse.fibers.Suspendable;
@@ -22,6 +23,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import sun.misc.Unsafe;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -149,7 +152,7 @@ public class AbstractFuture<V> implements Future<V> {
 
     static {
         try {
-            settingOffset = UNSAFE.objectFieldOffset(AbstractFuture.class.getDeclaredField("setting"));
+            settingOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(AbstractFuture.class, "setting")));
         } catch (Exception ex) {
             throw new AssertionError(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/OwnedSynchronizer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/OwnedSynchronizer.java
@@ -13,9 +13,12 @@
  */
 package co.paralleluniverse.strands;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import co.paralleluniverse.fibers.SuspendExecution;
 import sun.misc.Unsafe;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -71,7 +74,7 @@ public class OwnedSynchronizer extends ConditionSynchronizer implements Conditio
 
     static {
         try {
-            waiterOffset = UNSAFE.objectFieldOffset(OwnedSynchronizer.class.getDeclaredField("waiter"));
+            waiterOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(OwnedSynchronizer.class, "waiter")));
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/OwnedSynchronizer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/OwnedSynchronizer.java
@@ -17,6 +17,7 @@ import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import co.paralleluniverse.fibers.SuspendExecution;
 import sun.misc.Unsafe;
+import java.security.PrivilegedActionException;
 
 import static java.security.AccessController.doPrivileged;
 
@@ -75,6 +76,8 @@ public class OwnedSynchronizer extends ConditionSynchronizer implements Conditio
     static {
         try {
             waiterOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(OwnedSynchronizer.class, "waiter")));
+        } catch (PrivilegedActionException ex) {
+            throw new Error(ex.getCause());
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/channels/Selector.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/channels/Selector.java
@@ -22,6 +22,7 @@ import co.paralleluniverse.fibers.SuspendExecution;
 import co.paralleluniverse.strands.Strand;
 import co.paralleluniverse.strands.Synchronization;
 import co.paralleluniverse.strands.Timeout;
+import java.security.PrivilegedActionException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -524,6 +525,8 @@ public class Selector<Message> implements Synchronization {
     static {
         try {
             winnerOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Selector.class, "winner")));
+        } catch (PrivilegedActionException ex) {
+            throw new Error(ex.getCause());
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/channels/Selector.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/channels/Selector.java
@@ -15,6 +15,7 @@ package co.paralleluniverse.strands.channels;
 
 import co.paralleluniverse.common.monitoring.FlightRecorder;
 import co.paralleluniverse.common.monitoring.FlightRecorderMessage;
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.Debug;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import co.paralleluniverse.fibers.SuspendExecution;
@@ -30,7 +31,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import sun.misc.Unsafe;
 
-/**
+import static java.security.AccessController.doPrivileged;
+
+ /**
  * Attempts to perform at most one channel operation (send or receive) of a given set.
  *
  * @author pron
@@ -520,7 +523,7 @@ public class Selector<Message> implements Synchronization {
 
     static {
         try {
-            winnerOffset = UNSAFE.objectFieldOffset(Selector.class.getDeclaredField("winner"));
+            winnerOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Selector.class, "winner")));
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/channels/TransferChannel.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/channels/TransferChannel.java
@@ -28,6 +28,7 @@ import co.paralleluniverse.fibers.SuspendExecution;
 import co.paralleluniverse.strands.Strand;
 import co.paralleluniverse.strands.Synchronization;
 import co.paralleluniverse.strands.Timeout;
+import java.security.PrivilegedActionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -421,6 +422,8 @@ public class TransferChannel<Message> implements StandardChannel<Message>, Selec
                 saOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "sa")));
                 nextOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "next")));
                 waiterOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "waiter")));
+            } catch (PrivilegedActionException e) {
+                throw new Error(e.getCause());
             } catch (Exception e) {
                 throw new Error(e);
             }
@@ -912,6 +915,8 @@ public class TransferChannel<Message> implements StandardChannel<Message>, Selec
             headOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "head")));
             tailOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "tail")));
             sweepVotesOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "sweepVotes")));
+        } catch (PrivilegedActionException e) {
+            throw new Error(e.getCause());
         } catch (Exception e) {
             throw new Error(e);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/channels/TransferChannel.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/channels/TransferChannel.java
@@ -21,6 +21,7 @@
  */
 package co.paralleluniverse.strands.channels;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.DelegatingEquals;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import co.paralleluniverse.fibers.SuspendExecution;
@@ -29,6 +30,8 @@ import co.paralleluniverse.strands.Synchronization;
 import co.paralleluniverse.strands.Timeout;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -414,10 +417,10 @@ public class TransferChannel<Message> implements StandardChannel<Message>, Selec
             try {
                 UNSAFE = UtilUnsafe.getUnsafe();
                 Class k = Node.class;
-                itemOffset = UNSAFE.objectFieldOffset(k.getDeclaredField("item"));
-                saOffset = UNSAFE.objectFieldOffset(k.getDeclaredField("sa"));
-                nextOffset = UNSAFE.objectFieldOffset(k.getDeclaredField("next"));
-                waiterOffset = UNSAFE.objectFieldOffset(k.getDeclaredField("waiter"));
+                itemOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "item")));
+                saOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "sa")));
+                nextOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "next")));
+                waiterOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "waiter")));
             } catch (Exception e) {
                 throw new Error(e);
             }
@@ -906,9 +909,9 @@ public class TransferChannel<Message> implements StandardChannel<Message>, Selec
         try {
             UNSAFE = UtilUnsafe.getUnsafe();
             Class k = TransferChannel.class;
-            headOffset = UNSAFE.objectFieldOffset(k.getDeclaredField("head"));
-            tailOffset = UNSAFE.objectFieldOffset(k.getDeclaredField("tail"));
-            sweepVotesOffset = UNSAFE.objectFieldOffset(k.getDeclaredField("sweepVotes"));
+            headOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "head")));
+            tailOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "tail")));
+            sweepVotesOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "sweepVotes")));
         } catch (Exception e) {
             throw new Error(e);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/AbstractQueuedLongSynchronizer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/AbstractQueuedLongSynchronizer.java
@@ -31,6 +31,7 @@
 
 package co.paralleluniverse.strands.concurrent;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import co.paralleluniverse.fibers.SuspendExecution;
 import co.paralleluniverse.fibers.Suspendable;
@@ -41,6 +42,8 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.concurrent.locks.Condition;
 import sun.misc.Unsafe;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  * A version of {@link AbstractQueuedSynchronizer} in
@@ -2091,15 +2094,15 @@ public abstract class AbstractQueuedLongSynchronizer
     static {
         try {
             stateOffset = unsafe.objectFieldOffset
-                (AbstractQueuedLongSynchronizer.class.getDeclaredField("state"));
+                (doPrivileged(new GetDeclaredField(AbstractQueuedLongSynchronizer.class, "state")));
             headOffset = unsafe.objectFieldOffset
-                (AbstractQueuedLongSynchronizer.class.getDeclaredField("head"));
+                (doPrivileged(new GetDeclaredField(AbstractQueuedLongSynchronizer.class, "head")));
             tailOffset = unsafe.objectFieldOffset
-                (AbstractQueuedLongSynchronizer.class.getDeclaredField("tail"));
+                (doPrivileged(new GetDeclaredField(AbstractQueuedLongSynchronizer.class, "tail")));
             waitStatusOffset = unsafe.objectFieldOffset
-                (Node.class.getDeclaredField("waitStatus"));
+                (doPrivileged(new GetDeclaredField(Node.class, "waitStatus")));
             nextOffset = unsafe.objectFieldOffset
-                (Node.class.getDeclaredField("next"));
+                (doPrivileged(new GetDeclaredField(Node.class, "next")));
 
         } catch (Exception ex) { throw new Error(ex); }
     }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/AbstractQueuedLongSynchronizer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/AbstractQueuedLongSynchronizer.java
@@ -36,6 +36,7 @@ import co.paralleluniverse.common.util.UtilUnsafe;
 import co.paralleluniverse.fibers.SuspendExecution;
 import co.paralleluniverse.fibers.Suspendable;
 import co.paralleluniverse.strands.Strand;
+import java.security.PrivilegedActionException;
 import java.util.concurrent.TimeUnit;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -2103,7 +2104,8 @@ public abstract class AbstractQueuedLongSynchronizer
                 (doPrivileged(new GetDeclaredField(Node.class, "waitStatus")));
             nextOffset = unsafe.objectFieldOffset
                 (doPrivileged(new GetDeclaredField(Node.class, "next")));
-
+        } catch (PrivilegedActionException ex) {
+            throw new Error(ex.getCause());
         } catch (Exception ex) { throw new Error(ex); }
     }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/AbstractQueuedSynchronizer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/AbstractQueuedSynchronizer.java
@@ -38,6 +38,7 @@ import co.paralleluniverse.common.util.UtilUnsafe;
 import co.paralleluniverse.fibers.SuspendExecution;
 import co.paralleluniverse.fibers.Suspendable;
 import co.paralleluniverse.strands.Strand;
+import java.security.PrivilegedActionException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -2339,7 +2340,8 @@ public abstract class AbstractQueuedSynchronizer
                 (doPrivileged(new GetDeclaredField(Node.class, "waitStatus")));
             nextOffset = unsafe.objectFieldOffset
                 (doPrivileged(new GetDeclaredField(Node.class, "next")));
-
+        } catch (PrivilegedActionException ex) {
+            throw new Error(ex.getCause());
         } catch (Exception ex) { throw new Error(ex); }
     }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/AbstractQueuedSynchronizer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/AbstractQueuedSynchronizer.java
@@ -33,6 +33,7 @@
 
 package co.paralleluniverse.strands.concurrent;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import co.paralleluniverse.fibers.SuspendExecution;
 import co.paralleluniverse.fibers.Suspendable;
@@ -43,6 +44,8 @@ import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import sun.misc.Unsafe;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  * Provides a framework for implementing blocking locks and related
@@ -2327,15 +2330,15 @@ public abstract class AbstractQueuedSynchronizer
     static {
         try {
             stateOffset = unsafe.objectFieldOffset
-                (AbstractQueuedSynchronizer.class.getDeclaredField("state"));
+                (doPrivileged(new GetDeclaredField(AbstractQueuedSynchronizer.class, "state")));
             headOffset = unsafe.objectFieldOffset
-                (AbstractQueuedSynchronizer.class.getDeclaredField("head"));
+                (doPrivileged(new GetDeclaredField(AbstractQueuedSynchronizer.class, "head")));
             tailOffset = unsafe.objectFieldOffset
-                (AbstractQueuedSynchronizer.class.getDeclaredField("tail"));
+                (doPrivileged(new GetDeclaredField(AbstractQueuedSynchronizer.class, "tail")));
             waitStatusOffset = unsafe.objectFieldOffset
-                (Node.class.getDeclaredField("waitStatus"));
+                (doPrivileged(new GetDeclaredField(Node.class, "waitStatus")));
             nextOffset = unsafe.objectFieldOffset
-                (Node.class.getDeclaredField("next"));
+                (doPrivileged(new GetDeclaredField(Node.class, "next")));
 
         } catch (Exception ex) { throw new Error(ex); }
     }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/Phaser.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/Phaser.java
@@ -21,6 +21,7 @@
  */
 package co.paralleluniverse.strands.concurrent;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import co.paralleluniverse.fibers.SuspendExecution;
 import co.paralleluniverse.fibers.Suspendable;
@@ -29,6 +30,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  * A reusable synchronization barrier, similar in functionality to
@@ -1170,8 +1173,7 @@ public class Phaser {
     static {
         try {
             UNSAFE = UtilUnsafe.getUnsafe();
-            Class k = Phaser.class;
-            stateOffset = UNSAFE.objectFieldOffset(k.getDeclaredField("state"));
+            stateOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Phaser.class, "state")));
         } catch (Exception e) {
             throw new Error(e);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/Phaser.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/Phaser.java
@@ -26,6 +26,7 @@ import co.paralleluniverse.common.util.UtilUnsafe;
 import co.paralleluniverse.fibers.SuspendExecution;
 import co.paralleluniverse.fibers.Suspendable;
 import co.paralleluniverse.strands.Strand;
+import java.security.PrivilegedActionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -1174,6 +1175,8 @@ public class Phaser {
         try {
             UNSAFE = UtilUnsafe.getUnsafe();
             stateOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Phaser.class, "state")));
+        } catch (PrivilegedActionException e) {
+            throw new Error(e.getCause());
         } catch (Exception e) {
             throw new Error(e);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/StampedLock.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/StampedLock.java
@@ -21,6 +21,7 @@
  */
 package co.paralleluniverse.strands.concurrent;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import co.paralleluniverse.fibers.SuspendExecution;
 import co.paralleluniverse.fibers.Suspendable;
@@ -30,6 +31,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  * A capability-based lock with three modes for controlling read/write
@@ -1373,12 +1376,12 @@ public class StampedLock implements java.io.Serializable {
             U = UtilUnsafe.getUnsafe();
             Class<?> k = StampedLock.class;
             Class<?> wk = WNode.class;
-            STATE = U.objectFieldOffset(k.getDeclaredField("state"));
-            WHEAD = U.objectFieldOffset(k.getDeclaredField("whead"));
-            WTAIL = U.objectFieldOffset(k.getDeclaredField("wtail"));
-            WSTATUS = U.objectFieldOffset(wk.getDeclaredField("status"));
-            WNEXT = U.objectFieldOffset(wk.getDeclaredField("next"));
-            WCOWAIT = U.objectFieldOffset(wk.getDeclaredField("cowait"));
+            STATE = U.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "state")));
+            WHEAD = U.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "whead")));
+            WTAIL = U.objectFieldOffset(doPrivileged(new GetDeclaredField(k, "wtail")));
+            WSTATUS = U.objectFieldOffset(doPrivileged(new GetDeclaredField(wk, "status")));
+            WNEXT = U.objectFieldOffset(doPrivileged(new GetDeclaredField(wk, "next")));
+            WCOWAIT = U.objectFieldOffset(doPrivileged(new GetDeclaredField(wk, "cowait")));
 
         } catch (Exception e) {
             throw new Error(e);

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/StampedLock.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/concurrent/StampedLock.java
@@ -26,6 +26,7 @@ import co.paralleluniverse.common.util.UtilUnsafe;
 import co.paralleluniverse.fibers.SuspendExecution;
 import co.paralleluniverse.fibers.Suspendable;
 import co.paralleluniverse.strands.Strand;
+import java.security.PrivilegedActionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
@@ -1382,7 +1383,8 @@ public class StampedLock implements java.io.Serializable {
             WSTATUS = U.objectFieldOffset(doPrivileged(new GetDeclaredField(wk, "status")));
             WNEXT = U.objectFieldOffset(doPrivileged(new GetDeclaredField(wk, "next")));
             WCOWAIT = U.objectFieldOffset(doPrivileged(new GetDeclaredField(wk, "cowait")));
-
+        } catch (PrivilegedActionException e) {
+            throw new Error(e.getCause());
         } catch (Exception e) {
             throw new Error(e);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/ArrayQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/ArrayQueue.java
@@ -13,8 +13,11 @@
  */
 package co.paralleluniverse.strands.queues;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import sun.misc.Unsafe;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -121,8 +124,8 @@ public class ArrayQueue<E> implements BasicQueue<E> {
 
     static {
         try {
-            headOffset = UNSAFE.objectFieldOffset(ArrayQueue.class.getDeclaredField("head"));
-            tailOffset = UNSAFE.objectFieldOffset(ArrayQueue.class.getDeclaredField("tail"));
+            headOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(ArrayQueue.class, "head")));
+            tailOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(ArrayQueue.class, "tail")));
 
             base = UNSAFE.arrayBaseOffset(Object[].class);
             int scale = UNSAFE.arrayIndexScale(Object[].class);

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/ArrayQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/ArrayQueue.java
@@ -16,6 +16,7 @@ package co.paralleluniverse.strands.queues;
 import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import sun.misc.Unsafe;
+import java.security.PrivilegedActionException;
 
 import static java.security.AccessController.doPrivileged;
 
@@ -132,6 +133,8 @@ public class ArrayQueue<E> implements BasicQueue<E> {
             if ((scale & (scale - 1)) != 0)
                 throw new Error("data type scale not a power of two");
             shift = 31 - Integer.numberOfLeadingZeros(scale);
+        } catch (PrivilegedActionException ex) {
+            throw new Error(ex.getCause());
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/BoxQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/BoxQueue.java
@@ -16,6 +16,7 @@ package co.paralleluniverse.strands.queues;
 import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import sun.misc.Unsafe;
+import java.security.PrivilegedActionException;
 
 import static java.security.AccessController.doPrivileged;
 
@@ -83,6 +84,8 @@ public class BoxQueue<E> implements BasicQueue<E> {
     static {
         try {
             valueOffset = unsafe.objectFieldOffset(doPrivileged(new GetDeclaredField(BoxQueue.class, "value")));
+        } catch (PrivilegedActionException ex) {
+            throw new Error(ex.getCause());
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/BoxQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/BoxQueue.java
@@ -13,8 +13,11 @@
  */
 package co.paralleluniverse.strands.queues;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import sun.misc.Unsafe;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -79,7 +82,7 @@ public class BoxQueue<E> implements BasicQueue<E> {
 
     static {
         try {
-            valueOffset = unsafe.objectFieldOffset(BoxQueue.class.getDeclaredField("value"));
+            valueOffset = unsafe.objectFieldOffset(doPrivileged(new GetDeclaredField(BoxQueue.class, "value")));
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/CircularBuffer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/CircularBuffer.java
@@ -16,6 +16,7 @@ package co.paralleluniverse.strands.queues;
 import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import sun.misc.Unsafe;
+import java.security.PrivilegedActionException;
 
 import static java.security.AccessController.doPrivileged;
 
@@ -185,6 +186,8 @@ public abstract class CircularBuffer<E> implements BasicQueue<E> {
         try {
             tailOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(CircularBuffer.class, "tail")));
             lastWrittenOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(CircularBuffer.class, "lastWritten")));
+        } catch (PrivilegedActionException ex) {
+            throw new Error(ex.getCause());
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/CircularBuffer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/CircularBuffer.java
@@ -13,8 +13,11 @@
  */
 package co.paralleluniverse.strands.queues;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import sun.misc.Unsafe;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -180,8 +183,8 @@ public abstract class CircularBuffer<E> implements BasicQueue<E> {
 
     static {
         try {
-            tailOffset = UNSAFE.objectFieldOffset(CircularBuffer.class.getDeclaredField("tail"));
-            lastWrittenOffset = UNSAFE.objectFieldOffset(CircularBuffer.class.getDeclaredField("lastWritten"));
+            tailOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(CircularBuffer.class, "tail")));
+            lastWrittenOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(CircularBuffer.class, "lastWritten")));
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerArrayPrimitiveQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerArrayPrimitiveQueue.java
@@ -14,6 +14,7 @@
 package co.paralleluniverse.strands.queues;
 
 import co.paralleluniverse.common.reflection.GetDeclaredField;
+import java.security.PrivilegedActionException;
 
 import static java.security.AccessController.doPrivileged;
 
@@ -66,6 +67,8 @@ abstract class SingleConsumerArrayPrimitiveQueue<E> extends SingleConsumerArrayQ
     static {
         try {
             maxReadIndexOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(SingleConsumerArrayPrimitiveQueue.class, "maxReadIndex")));
+        } catch (PrivilegedActionException ex) {
+            throw new Error(ex.getCause());
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerArrayPrimitiveQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerArrayPrimitiveQueue.java
@@ -13,6 +13,10 @@
  */
 package co.paralleluniverse.strands.queues;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
+
+import static java.security.AccessController.doPrivileged;
+
 /**
  *
  * @author pron
@@ -61,7 +65,7 @@ abstract class SingleConsumerArrayPrimitiveQueue<E> extends SingleConsumerArrayQ
 
     static {
         try {
-            maxReadIndexOffset = UNSAFE.objectFieldOffset(SingleConsumerArrayPrimitiveQueue.class.getDeclaredField("maxReadIndex"));
+            maxReadIndexOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(SingleConsumerArrayPrimitiveQueue.class, "maxReadIndex")));
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerArrayQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerArrayQueue.java
@@ -16,6 +16,7 @@ package co.paralleluniverse.strands.queues;
 import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import com.google.common.collect.Lists;
+import java.security.PrivilegedActionException;
 import java.util.ArrayList;
 import java.util.List;
 import sun.misc.Unsafe;
@@ -246,6 +247,8 @@ abstract class SingleConsumerArrayQueue<E> extends SingleConsumerQueue<E> {
         try {
             headOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(SingleConsumerArrayQueue.class, "head")));
             tailOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(SingleConsumerArrayQueue.class, "tail")));
+        } catch (PrivilegedActionException ex) {
+            throw new Error(ex.getCause());
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerArrayQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerArrayQueue.java
@@ -13,11 +13,14 @@
  */
 package co.paralleluniverse.strands.queues;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
 import sun.misc.Unsafe;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -241,8 +244,8 @@ abstract class SingleConsumerArrayQueue<E> extends SingleConsumerQueue<E> {
 
     static {
         try {
-            headOffset = UNSAFE.objectFieldOffset(SingleConsumerArrayQueue.class.getDeclaredField("head"));
-            tailOffset = UNSAFE.objectFieldOffset(SingleConsumerArrayQueue.class.getDeclaredField("tail"));
+            headOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(SingleConsumerArrayQueue.class, "head")));
+            tailOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(SingleConsumerArrayQueue.class, "tail")));
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedArrayPrimitiveQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedArrayPrimitiveQueue.java
@@ -13,7 +13,11 @@
  */
 package co.paralleluniverse.strands.queues;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
+
 import java.util.NoSuchElementException;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -114,8 +118,8 @@ public abstract class SingleConsumerLinkedArrayPrimitiveQueue<E> extends SingleC
 
     static {
         try {
-            tailIndexOffset = UNSAFE.objectFieldOffset(PrimitiveNode.class.getDeclaredField("tailIndex"));
-            maxReadIndexOffset = UNSAFE.objectFieldOffset(PrimitiveNode.class.getDeclaredField("maxReadIndex"));
+            tailIndexOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(PrimitiveNode.class, "tailIndex")));
+            maxReadIndexOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(PrimitiveNode.class, "maxReadIndex")));
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedArrayPrimitiveQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedArrayPrimitiveQueue.java
@@ -14,7 +14,7 @@
 package co.paralleluniverse.strands.queues;
 
 import co.paralleluniverse.common.reflection.GetDeclaredField;
-
+import java.security.PrivilegedActionException;
 import java.util.NoSuchElementException;
 
 import static java.security.AccessController.doPrivileged;
@@ -120,6 +120,8 @@ public abstract class SingleConsumerLinkedArrayPrimitiveQueue<E> extends SingleC
         try {
             tailIndexOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(PrimitiveNode.class, "tailIndex")));
             maxReadIndexOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(PrimitiveNode.class, "maxReadIndex")));
+        } catch (PrivilegedActionException ex) {
+            throw new Error(ex.getCause());
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedArrayQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedArrayQueue.java
@@ -16,6 +16,7 @@ package co.paralleluniverse.strands.queues;
 import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import com.google.common.collect.Lists;
+import java.security.PrivilegedActionException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -320,6 +321,8 @@ abstract class SingleConsumerLinkedArrayQueue<E> extends SingleConsumerQueue<E> 
             tailOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(SingleConsumerLinkedArrayQueue.class, "tail")));
             nextOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Node.class, "next")));
             prevOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Node.class, "prev")));
+        } catch (PrivilegedActionException ex) {
+            throw new Error(ex.getCause());
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedArrayQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedArrayQueue.java
@@ -13,12 +13,15 @@
  */
 package co.paralleluniverse.strands.queues;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import sun.misc.Unsafe;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -313,10 +316,10 @@ abstract class SingleConsumerLinkedArrayQueue<E> extends SingleConsumerQueue<E> 
 
     static {
         try {
-            headOffset = UNSAFE.objectFieldOffset(SingleConsumerLinkedArrayQueue.class.getDeclaredField("head"));
-            tailOffset = UNSAFE.objectFieldOffset(SingleConsumerLinkedArrayQueue.class.getDeclaredField("tail"));
-            nextOffset = UNSAFE.objectFieldOffset(Node.class.getDeclaredField("next"));
-            prevOffset = UNSAFE.objectFieldOffset(Node.class.getDeclaredField("prev"));
+            headOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(SingleConsumerLinkedArrayQueue.class, "head")));
+            tailOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(SingleConsumerLinkedArrayQueue.class, "tail")));
+            nextOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Node.class, "next")));
+            prevOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Node.class, "prev")));
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedObjectQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedObjectQueue.java
@@ -15,6 +15,7 @@ package co.paralleluniverse.strands.queues;
 
 import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.Objects;
+import java.security.PrivilegedActionException;
 
 import static java.security.AccessController.doPrivileged;
 
@@ -55,6 +56,8 @@ public class SingleConsumerLinkedObjectQueue<E> extends SingleConsumerLinkedQueu
     static {
         try {
             valueOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(ObjectNode.class, "value")));
+        } catch (PrivilegedActionException ex) {
+            throw new Error(ex.getCause());
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedObjectQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedObjectQueue.java
@@ -13,7 +13,10 @@
  */
 package co.paralleluniverse.strands.queues;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.Objects;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -51,7 +54,7 @@ public class SingleConsumerLinkedObjectQueue<E> extends SingleConsumerLinkedQueu
 
     static {
         try {
-            valueOffset = UNSAFE.objectFieldOffset(ObjectNode.class.getDeclaredField("value"));
+            valueOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(ObjectNode.class, "value")));
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedQueue.java
@@ -13,11 +13,14 @@
  */
 package co.paralleluniverse.strands.queues;
 
+import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
 import sun.misc.Unsafe;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  *
@@ -268,10 +271,10 @@ abstract class SingleConsumerLinkedQueue<E> extends SingleConsumerQueue<E> {
 
     static {
         try {
-            headOffset = UNSAFE.objectFieldOffset(SingleConsumerLinkedQueue.class.getDeclaredField("head"));
-            tailOffset = UNSAFE.objectFieldOffset(SingleConsumerLinkedQueue.class.getDeclaredField("tail"));
-            nextOffset = UNSAFE.objectFieldOffset(Node.class.getDeclaredField("next"));
-            prevOffset = UNSAFE.objectFieldOffset(Node.class.getDeclaredField("prev"));
+            headOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(SingleConsumerLinkedQueue.class, "head")));
+            tailOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(SingleConsumerLinkedQueue.class, "tail")));
+            nextOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Node.class, "next")));
+            prevOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Node.class, "prev")));
         } catch (Exception ex) {
             throw new Error(ex);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedQueue.java
@@ -16,6 +16,7 @@ package co.paralleluniverse.strands.queues;
 import co.paralleluniverse.common.reflection.GetDeclaredField;
 import co.paralleluniverse.common.util.UtilUnsafe;
 import com.google.common.collect.Lists;
+import java.security.PrivilegedActionException;
 import java.util.ArrayList;
 import java.util.List;
 import sun.misc.Unsafe;
@@ -275,6 +276,8 @@ abstract class SingleConsumerLinkedQueue<E> extends SingleConsumerQueue<E> {
             tailOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(SingleConsumerLinkedQueue.class, "tail")));
             nextOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Node.class, "next")));
             prevOffset = UNSAFE.objectFieldOffset(doPrivileged(new GetDeclaredField(Node.class, "prev")));
+        } catch (PrivilegedActionException ex) {
+            throw new Error(ex.getCause());
         } catch (Exception ex) {
             throw new Error(ex);
         }


### PR DESCRIPTION
 Ensure that Java Reflection is handled as a privileged operation via `AccessController`. Note that `AccessController.doPrivileged()` is a `@CallerSensitive` operation and so which function it is invoked from is _critically important_ .

The permissions required are:
- `java.lang.RuntimePermission("accessDeclaredMembers")`, to query for declared `Constructor`, `Method` and `Field` objects,
- `java.lang.reflect.ReflectPermission("suppressAccessChecks")`, to use `Member.setAccessible(true)`