### PR TITLE
CORDA-3667: Add support for method overloads in quasar

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTrace.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTrace.java
@@ -82,9 +82,9 @@ public class ExtendedStackTrace implements Iterable<ExtendedStackTraceElement> {
         Member[] ms = getMethods(este.getDeclaringClass());
         Member method = null;
 
-        final String methodName = este.getMethodName();
+        final String targetMethodName = este.getMethodName();
         for (Member m : ms) {
-            if (methodName.equals(m.getName())) {
+            if (targetMethodName.equals(m.getName())) {
                 if (method == null)
                     method = m;
                 else {
@@ -94,8 +94,8 @@ public class ExtendedStackTrace implements Iterable<ExtendedStackTraceElement> {
             }
         }
 
-        final int lineNumber = este.getLineNumber();
-        if (method == null && lineNumber >= 0) {
+        final int targetLineNumber = este.getLineNumber();
+        if (method == null && targetLineNumber >= 0) {
             try {
                 final AtomicReference<String> exactMatch = new AtomicReference<>();
                 final AtomicReference<String> descriptor = new AtomicReference<>();
@@ -103,7 +103,7 @@ public class ExtendedStackTrace implements Iterable<ExtendedStackTraceElement> {
                     @Override
                     public MethodVisitor visitMethod(int access, String name, final String desc, String signature, String[] exceptions) {
                         MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
-                        if (exactMatch.get() == null && methodName.equals(name)) {
+                        if (exactMatch.get() == null && targetMethodName.equals(name)) {
                             mv = new MethodVisitor(api, mv) {
                                 int minLine = Integer.MAX_VALUE, maxLine = Integer.MIN_VALUE;
 
@@ -113,13 +113,13 @@ public class ExtendedStackTrace implements Iterable<ExtendedStackTraceElement> {
                                         minLine = line;
                                     if (line > maxLine)
                                         maxLine = line;
-                                    if (lineNumber == line)
+                                    if (targetLineNumber == line)
                                         exactMatch.set(desc);
                                 }
 
                                 @Override
                                 public void visitEnd() {
-                                    if (minLine <= lineNumber && maxLine >= lineNumber && descriptor.get() == null)
+                                    if (minLine <= targetLineNumber && maxLine >= targetLineNumber && descriptor.get() == null)
                                         descriptor.set(desc);
                                     super.visitEnd();
                                 }
@@ -130,10 +130,10 @@ public class ExtendedStackTrace implements Iterable<ExtendedStackTraceElement> {
                 });
 
                 if (exactMatch.get() != null){
-                    method = getMatchingMethod(ms, methodName, exactMatch.get());
+                    method = getMatchingMethod(ms, targetMethodName, exactMatch.get());
                 }
                 else if (descriptor.get() != null) {
-                    method = getMatchingMethod(ms, methodName, descriptor.get());
+                    method = getMatchingMethod(ms, targetMethodName, descriptor.get());
                 }
             } catch (Exception e) {
                 if (!(e instanceof UnsupportedOperationException))

--- a/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTrace.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTrace.java
@@ -119,7 +119,7 @@ public class ExtendedStackTrace implements Iterable<ExtendedStackTraceElement> {
 
                                 @Override
                                 public void visitEnd() {
-                                    if (minLine <= lineNumber && maxLine >= lineNumber)
+                                    if (minLine <= lineNumber && maxLine >= lineNumber && descriptor.get() == null)
                                         descriptor.set(desc);
                                     super.visitEnd();
                                 }

--- a/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTrace.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTrace.java
@@ -82,8 +82,9 @@ public class ExtendedStackTrace implements Iterable<ExtendedStackTraceElement> {
         Member[] ms = getMethods(este.getDeclaringClass());
         Member method = null;
 
+        final String methodName = este.getMethodName();
         for (Member m : ms) {
-            if (este.getMethodName().equals(m.getName())) {
+            if (methodName.equals(m.getName())) {
                 if (method == null)
                     method = m;
                 else {
@@ -92,14 +93,17 @@ public class ExtendedStackTrace implements Iterable<ExtendedStackTraceElement> {
                 }
             }
         }
-        if (method == null && este.getLineNumber() >= 0) {
+
+        final int lineNumber = este.getLineNumber();
+        if (method == null && lineNumber >= 0) {
             try {
+                final AtomicReference<String> exactMatch = new AtomicReference<>();
                 final AtomicReference<String> descriptor = new AtomicReference<>();
                 ASMUtil.accept(este.getDeclaringClass(), ClassReader.SKIP_FRAMES, new ClassVisitor(Opcodes.ASM5) {
                     @Override
                     public MethodVisitor visitMethod(int access, String name, final String desc, String signature, String[] exceptions) {
                         MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
-                        if (descriptor.get() == null && este.getMethodName().equals(name)) {
+                        if (exactMatch.get() == null && methodName.equals(name)) {
                             mv = new MethodVisitor(api, mv) {
                                 int minLine = Integer.MAX_VALUE, maxLine = Integer.MIN_VALUE;
 
@@ -109,11 +113,13 @@ public class ExtendedStackTrace implements Iterable<ExtendedStackTraceElement> {
                                         minLine = line;
                                     if (line > maxLine)
                                         maxLine = line;
+                                    if (lineNumber == line)
+                                        exactMatch.set(desc);
                                 }
 
                                 @Override
                                 public void visitEnd() {
-                                    if (minLine <= este.getLineNumber() && maxLine >= este.getLineNumber())
+                                    if (minLine <= lineNumber && maxLine >= lineNumber)
                                         descriptor.set(desc);
                                     super.visitEnd();
                                 }
@@ -123,14 +129,11 @@ public class ExtendedStackTrace implements Iterable<ExtendedStackTraceElement> {
                     }
                 });
 
-                if (descriptor.get() != null) {
-                    final String desc = descriptor.get();
-                    for (Member m : ms) {
-                        if (este.getMethodName().equals(getName(m)) && desc.equals(getDescriptor(m))) {
-                            method = m;
-                            break;
-                        }
-                    }
+                if (exactMatch.get() != null){
+                    method = getMatchingMethod(ms, methodName, exactMatch.get());
+                }
+                else if (descriptor.get() != null) {
+                    method = getMatchingMethod(ms, methodName, descriptor.get());
                 }
             } catch (Exception e) {
                 if (!(e instanceof UnsupportedOperationException))
@@ -139,6 +142,15 @@ public class ExtendedStackTrace implements Iterable<ExtendedStackTraceElement> {
         }
 
         return method;
+    }
+
+    private Member getMatchingMethod(Member[] methods, String methodName, String desc) {
+        for (Member m : methods) {
+            if (methodName.equals(getName(m)) && desc.equals(getDescriptor(m))) {
+                return m;
+            }
+        }
+        return null;
     }
 
     protected static final String getName(Member m) {

--- a/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTrace.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTrace.java
@@ -119,8 +119,8 @@ public class ExtendedStackTrace implements Iterable<ExtendedStackTraceElement> {
 
                                 @Override
                                 public void visitEnd() {
-                                    if (minLine <= targetLineNumber && maxLine >= targetLineNumber && descriptor.get() == null)
-                                        descriptor.set(desc);
+                                    if (minLine <= targetLineNumber && maxLine >= targetLineNumber)
+                                        descriptor.compareAndSet(null, desc);
                                     super.visitEnd();
                                 }
                             };
@@ -129,11 +129,13 @@ public class ExtendedStackTrace implements Iterable<ExtendedStackTraceElement> {
                     }
                 });
 
-                if (exactMatch.get() != null){
-                    method = getMatchingMethod(ms, targetMethodName, exactMatch.get());
+                String exactMatchValue = exactMatch.get();
+                String descriptorValue = descriptor.get();
+                if (exactMatchValue != null){
+                    method = getMatchingMethod(ms, targetMethodName, exactMatchValue);
                 }
-                else if (descriptor.get() != null) {
-                    method = getMatchingMethod(ms, targetMethodName, descriptor.get());
+                else if (descriptorValue != null) {
+                    method = getMatchingMethod(ms, targetMethodName, descriptorValue);
                 }
             } catch (Exception e) {
                 if (!(e instanceof UnsupportedOperationException))

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/MethodOverloadTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/MethodOverloadTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Quasar: lightweight threads and actors for the JVM.
+ * Copyright (c) 2015-2017, Parallel Universe Software Co. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 3.0
+ * as published by the Free Software Foundation.
+ */
+package co.paralleluniverse.kotlin.fibers.lang
+
+import co.paralleluniverse.common.util.SystemProperties
+import co.paralleluniverse.fibers.Fiber
+import co.paralleluniverse.fibers.Suspendable
+import org.junit.Assume
+import org.junit.Test
+import kotlin.test.assertNotNull
+
+class MethodOverloadTest {
+
+    @Suspendable
+    fun function() {
+        function(arrayOf(0))
+    }
+
+    @Suspendable
+    fun function(m: Any) {
+        Fiber.yield()
+    }
+
+    private val verifyInstrumentation = "co.paralleluniverse.fibers.verifyInstrumentation"
+
+    @Test fun methodOverloadTest() {
+
+        withVerifyInstrumentationOn {
+            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(verifyInstrumentation))
+
+            val fiber = object : Fiber<Any>() {
+                @Suspendable
+                override fun run(): Any {
+                    return function(object {})
+                }
+            }
+
+            val actual = fiber.start().get()
+            assertNotNull(actual)
+        }
+    }
+
+    private fun <T> withVerifyInstrumentationOn(statement: () -> T): T{
+        val originalValue = System.getProperty(verifyInstrumentation)
+        System.setProperty(verifyInstrumentation, "true")
+        try {
+            return statement()
+        } finally {
+            if (originalValue == null) {
+                System.clearProperty(verifyInstrumentation)
+            } else {
+                System.setProperty(verifyInstrumentation, originalValue)
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This fix helps Quasar identify the correct method overload when running under OpenJDK.

Up until now, it has relied on the line number from a stack trace falling between the start and end line numbers for a method. I've found that it is possible for the compiler to pull a constant out of the method and give it a fake line number beyond the end of the file. That breaks Quasars search for the correct method overload. An example can be seen in CORDA-3667.

This fix makes Quasar prefer a method where it sees an exact match to the line number in the stack trace and falls back on existing behaviour when that is not the case.

I've introduced variables for the line number and method name read from the stack trace object (`este`). I can reverse this for a simpler diff if requested.