### PR TITLE
CORDA-3666: Fix deadlock on node startup

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
@@ -33,17 +33,17 @@ public final class Classes {
     }));
 
     // Don't load the classes
-    static final String STACK_NAME       = "co.paralleluniverse.fibers.Stack".replace('.', '/');
-    static final String FIBER_CLASS_NAME = "co.paralleluniverse.fibers.Fiber".replace('.', '/');
-    static final String STRAND_NAME      = "co.paralleluniverse.strands.Strand".replace('.', '/');
+    static final String STACK_NAME       = "co/paralleluniverse/fibers/Stack";
+    static final String FIBER_CLASS_NAME = "co/paralleluniverse/fibers/Fiber";
+    static final String STRAND_NAME      = "co/paralleluniverse/strands/Strand";
 
-    static final String THROWABLE_NAME         = "java.lang.Throwable".replace('.', '/');
-    static final String EXCEPTION_NAME         = "java.lang.Exception".replace('.', '/');
-    static final String RUNTIME_EXCEPTION_NAME = "java.lang.RuntimeException".replace('.', '/');
+    static final String THROWABLE_NAME         = "java/lang/Throwable";
+    static final String EXCEPTION_NAME         = "java/lang/Exception";
+    static final String RUNTIME_EXCEPTION_NAME = "java/lang/RuntimeException";
 
-    static final String RUNTIME_SUSPEND_EXECUTION_NAME = "co.paralleluniverse.fibers.RuntimeSuspendExecution".replace('.', '/');
-    static final String UNDECLARED_THROWABLE_NAME      = "java.lang.reflect.UndeclaredThrowableException".replace('.', '/');
-    static final String SUSPEND_EXECUTION_NAME         = "co.paralleluniverse.fibers.SuspendExecution".replace('.', '/');
+    static final String RUNTIME_SUSPEND_EXECUTION_NAME = "co/paralleluniverse/fibers/RuntimeSuspendExecution";
+    static final String UNDECLARED_THROWABLE_NAME      = "java/lang/reflect/UndeclaredThrowableException";
+    static final String SUSPEND_EXECUTION_NAME         = "co/paralleluniverse/fibers/SuspendExecution";
     
     // computed
     // static final String EXCEPTION_DESC = "L" + SUSPEND_EXECUTION_NAME + ";";

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
@@ -13,15 +13,9 @@
  */
 package co.paralleluniverse.fibers.instrument;
 
-import co.paralleluniverse.fibers.*;
-
-import java.lang.reflect.UndeclaredThrowableException;
-import java.util.*;
-
-import co.paralleluniverse.fibers.Stack;
-import co.paralleluniverse.strands.Strand;
-import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.MethodInsnNode;
+
+import java.util.*;
 
 /**
  * This class contains hard-coded values with the names of the classes and methods relevant for instrumentation.
@@ -39,23 +33,23 @@ public final class Classes {
     }));
 
     // Don't load the classes
-    static final String STACK_NAME       = /*Stack.class.getName()*/ "co.paralleluniverse.fibers.Stack".replace('.', '/');
-    static final String FIBER_CLASS_NAME = /*Fiber.class.getName()*/ "co.paralleluniverse.fibers.Fiber".replace('.', '/');
-    static final String STRAND_NAME      = /*Strand.class.getName()*/"co.paralleluniverse.strands.Strand".replace('.', '/');
+    static final String STACK_NAME       = "co.paralleluniverse.fibers.Stack".replace('.', '/');
+    static final String FIBER_CLASS_NAME = "co.paralleluniverse.fibers.Fiber".replace('.', '/');
+    static final String STRAND_NAME      = "co.paralleluniverse.strands.Strand".replace('.', '/');
 
-    static final String THROWABLE_NAME         = Throwable.class.getName().replace('.', '/');
-    static final String EXCEPTION_NAME         = Exception.class.getName().replace('.', '/');
-    static final String RUNTIME_EXCEPTION_NAME = RuntimeException.class.getName().replace('.', '/');
+    static final String THROWABLE_NAME         = "java.lang.Throwable".replace('.', '/');
+    static final String EXCEPTION_NAME         = "java.lang.Exception".replace('.', '/');
+    static final String RUNTIME_EXCEPTION_NAME = "java.lang.RuntimeException".replace('.', '/');
 
-    static final String RUNTIME_SUSPEND_EXECUTION_NAME = RuntimeSuspendExecution.class.getName().replace('.', '/');
-    static final String UNDECLARED_THROWABLE_NAME      = UndeclaredThrowableException.class.getName().replace('.', '/');
-    static final String SUSPEND_EXECUTION_NAME         = SuspendExecution.class.getName().replace('.', '/');
+    static final String RUNTIME_SUSPEND_EXECUTION_NAME = "co.paralleluniverse.fibers.RuntimeSuspendExecution".replace('.', '/');
+    static final String UNDECLARED_THROWABLE_NAME      = "java.lang.reflect.UndeclaredThrowableException".replace('.', '/');
+    static final String SUSPEND_EXECUTION_NAME         = "co.paralleluniverse.fibers.SuspendExecution".replace('.', '/');
     
     // computed
     // static final String EXCEPTION_DESC = "L" + SUSPEND_EXECUTION_NAME + ";";
-    static final String SUSPENDABLE_DESC = Type.getDescriptor(Suspendable.class);
-    static final String DONT_INSTRUMENT_DESC = Type.getDescriptor(DontInstrument.class);
-    static final String INSTRUMENTED_DESC = Type.getDescriptor(Instrumented.class);
+    static final String SUSPENDABLE_DESC     = "Lco/paralleluniverse/fibers/Suspendable;";               // Type.getDescriptor(Suspendable.class);
+    static final String DONT_INSTRUMENT_DESC = "Lco/paralleluniverse/fibers/instrument/DontInstrument;"; // Type.getDescriptor(DontInstrument.class);
+    static final String INSTRUMENTED_DESC    = "Lco/paralleluniverse/fibers/Instrumented;";              // Type.getDescriptor(Instrumented.class);
     static final String LAMBDA_METHOD_PREFIX = "lambda$";
 
     static boolean isYieldMethod(String className, String methodName) {


### PR DESCRIPTION
Attempt to fix the deadlock seen on node startup by removing the need for class loading in `Classes.<clinit>`.

The normal fix for deadlock is to impose a lock hierarchy but in this case it seems the JVM itself is waiting for `clinit` so we can't impose anything on that lock. I've gone for removing one side of the work causing deadlock.

I'm afraid I don't have a unit test to reproduce the issue. I've seen the issue in a debugger after a node froze during startup. I expect this to help the situation but cannot prove it.