### PR TITLE
CORDA-3666: Access the Classes class before we hook into the JVM

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
@@ -100,6 +100,12 @@ public class JavaAgent {
     private static final Set<WeakReference<ClassLoader>> classLoaders = Collections.newSetFromMap(MapUtil.<WeakReference<ClassLoader>, Boolean>newConcurrentHashMap());
 
     public static void premain(String agentArguments, Instrumentation instrumentation) {
+
+        // CORDA-3666: Access Classes now so we don't deadlock while
+        // loading it later.
+        //noinspection ResultOfMethodCallIgnored
+        Classes.SUSPEND_EXECUTION_NAME.isEmpty();
+
         if (!instrumentation.isRetransformClassesSupported())
             System.err.println("Retransforming classes is not supported!");
 

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
@@ -185,7 +185,10 @@ public class JavaAgent {
 
         // CORDA-3666: Access Classes now so we don't deadlock while
         // loading it later.
-        // We expect this call to isYieldMethod to return true.
+        //
+        // We are calling isYieldMethod for the side effect of the JVM
+        // running Classes.<clinit>. We expect this call to return
+        // true.
         // Prints "Classes ready: true"
         instrumentor.log(LogLevel.DEBUG, "Classes ready: %s", Classes.isYieldMethod(Classes.FIBER_CLASS_NAME, "park"));
 

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
@@ -101,11 +101,6 @@ public class JavaAgent {
 
     public static void premain(String agentArguments, Instrumentation instrumentation) {
 
-        // CORDA-3666: Access Classes now so we don't deadlock while
-        // loading it later.
-        //noinspection ResultOfMethodCallIgnored
-        Classes.SUSPEND_EXECUTION_NAME.isEmpty();
-
         if (!instrumentation.isRetransformClassesSupported())
             System.err.println("Retransforming classes is not supported!");
 
@@ -188,6 +183,12 @@ public class JavaAgent {
                 exc.printStackTrace(System.err);
             }
         });
+
+        // CORDA-3666: Access Classes now so we don't deadlock while
+        // loading it later.
+        // We expect this call to isYieldMethod to return true.
+        // Prints "Classes ready: true"
+        instrumentor.log(LogLevel.DEBUG, "Classes ready: %s", Classes.isYieldMethod(Classes.FIBER_CLASS_NAME, "park"));
 
         Retransform.instrumentation = instrumentation;
         Retransform.instrumentor = instrumentor;

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
@@ -100,7 +100,6 @@ public class JavaAgent {
     private static final Set<WeakReference<ClassLoader>> classLoaders = Collections.newSetFromMap(MapUtil.<WeakReference<ClassLoader>, Boolean>newConcurrentHashMap());
 
     public static void premain(String agentArguments, Instrumentation instrumentation) {
-
         if (!instrumentation.isRetransformClassesSupported())
             System.err.println("Retransforming classes is not supported!");
 


### PR DESCRIPTION
Access the `Classes` class before we hook into the JVM, so static initialisation completes before Quasar starts work.

One concern is the optimiser removing unused code. To avoid that, I've written a debug log message while calling a static method and accessing a static field on the `Classes` class.

An alternative fix for https://github.com/corda/quasar/pull/10