### PR TITLE
NOTICK: Fix subtle build errors caused by Gradle daemon.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,5 @@ taskTreeVersion=1.3.1
 shadowVersion=5.2.0
 artifactoryVersion=4.16.1
 modulepluginVersion=1.7.0
+
+org.gradle.daemon=false

--- a/quasar-core/src/main/java/co/paralleluniverse/common/util/Debug.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/util/Debug.java
@@ -55,7 +55,7 @@ public class Debug {
         for (StackTraceElement ste : stack) {
             if (ste.getClassName().startsWith("org.junit")
                     || ste.getClassName().startsWith("junit.framework")
-                    || ste.getClassName().contains("JUnitTestClassExecuter")) {
+                    || ste.getClassName().contains("JUnitTestClass")) {
                 isUnitTest = true;
                 break;
             }

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/ReflectionInvokeTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/ReflectionInvokeTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
  * @author Matthias Mann
  */
 public class ReflectionInvokeTest {
-    private ArrayList<String> results = new ArrayList<String>();
+    private final ArrayList<String> results = new ArrayList<>();
 
     private String suspendableMethod() throws SuspendExecution {
         Fiber.park();


### PR DESCRIPTION
Gradle uses the `quasar-core` build artifact to run the tests, which means that the Gradle daemon will crash if this artifact is subsequently modified on disk. It's probably safer _not_ to use a Gradle daemon at all for building Quasar.

Also, Quasar by default will refuse to instrument classes from the `co.paralleluniverse.fibers.instrument` package. This is fine _except_ for running instrumentation unit tests. Quasar tries to spot when it's being unit tested, but the logic has a spelling mistake! (Either that, or Gradle 4.x _had_ a spelling mistake which Gradle 5.x has now fixed.). Update this `Debug` logic so that `ReflectionInvokeTest` can be executed correctly _in isolation_ from within IntelliJ.