### PR TITLE
CORDA-4032: Evaluate Gradle provider lazily as a bnd macro.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -467,6 +467,10 @@ project (':quasar-core') {
         }
     }
 
+    ext {
+        shadowJarURI = shadowJar.archiveFile.map { it.asFile.toURI() }
+    }
+
     def bundle = tasks.register('bundle', Bundle) {
         dependsOn shadowJar
         from(zipTree(shadowJar.archiveFile)) {
@@ -491,7 +495,7 @@ project (':quasar-core') {
         bnd """
 Bundle-SymbolicName: co.paralleluniverse.quasar-core
 Bundle-Name: Quasar Fibers
-Bundle-Version: $version
+Bundle-Version: \${project.version}
 Import-Package: \
  org.LatencyUtils.*;resolution:=optional,\
  org.HdrHistogram.*;resolution:=optional,\
@@ -531,10 +535,10 @@ Import-Package: \
         archiveClassifier = 'agent'
 
         bnd """
--include: "jar:${shadowJar.archiveFile.map { it.asFile.toURI() }.get()}!/META-INF/MANIFEST.MF"
+-include: "jar:\${project.shadowJarURI}!/META-INF/MANIFEST.MF"
 Bundle-SymbolicName: co.paralleluniverse.quasar-core.agent
 Bundle-Name: Quasar Agent
-Bundle-Version: $version
+Bundle-Version: \${project.version}
 """
     }
 


### PR DESCRIPTION
Create a lazy `Provider` to evaluate the shaded jar's `file:` URI, and then assign it to a project property so that bnd can invoke it as a macro. This avoids using deprecated Gradle behaviour that will be removed in Gradle 7.0, but should otherwise have no noticeable effect.

Also evaluate `project.version` lazily, for good measure.