### PR TITLE
CORDA-4064: Add module-info for OSGi artifacts.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -386,6 +386,18 @@ project (':quasar-core') {
                 srcDir 'src/main/java'
             }
         }
+        agent {
+            java {
+                srcDir 'src/main/agent'
+            }
+            compileClasspath += main.compileClasspath
+        }
+        bundle {
+            java {
+                srcDir 'src/main/bundle'
+            }
+            compileClasspath += main.compileClasspath
+        }
 
         test {
             java {
@@ -414,6 +426,8 @@ project (':quasar-core') {
 
     configurations {
         compileClasspath.extendsFrom provided
+        bundleImplementation.extendsFrom implementation
+        bundleImplementation.extendsFrom agentImplementation
     }
 
     dependencies {
@@ -434,6 +448,28 @@ project (':quasar-core') {
         }
 
         compileOnly "org.osgi:osgi.annotation:$osgiVer"
+
+        agentImplementation files(sourceSets.main.output) {
+            builtBy tasks.named('compileJava', JavaCompile)
+        }
+        bundleImplementation files(sourceSets.agent.output) {
+            builtBy tasks.named('compileAgentJava', JavaCompile)
+        }
+    }
+
+    compileAgentJava {
+        options.compilerArgs += [
+            '--patch-module', "${project.moduleName}.agent=${sourceSets.main.output.asPath}",
+            '--module-version', project.version
+        ]
+    }
+
+    compileBundleJava {
+        options.compilerArgs += [
+            '--patch-module', "${project.moduleName}.osgi=${sourceSets.main.output.asPath}",
+            '--module-path', configurations.bundleCompileClasspath.asPath,
+            '--module-version', project.version
+        ]
     }
 
     // this happens after we've filtered the dependency on ASM from core's module-info
@@ -488,6 +524,7 @@ project (':quasar-core') {
             exclude 'co/paralleluniverse/fibers/instrument/**'
             exclude 'module-info.class'
         }
+        from(sourceSets.bundle.output)
         archiveAppendix = 'osgi'
 
         manifest {
@@ -496,7 +533,6 @@ project (':quasar-core') {
                 "Implementation-Title"      :   project.name,
                 "Implementation-Version"    :   archiveVersion.get(),
                 "Implementation-Vendor"     :   vendor,
-                "Automatic-Module-Name"     :   "${moduleName}.osgi",
             )
         }
 
@@ -539,6 +575,7 @@ Import-Package: \
             exclude 'co/paralleluniverse/fibers/instrument/OldSuspendablesScanner*'
             exclude 'co/paralleluniverse/fibers/instrument/SuspendablesScanner*'
         }
+        from(sourceSets.agent.output)
         archiveAppendix = 'osgi'
         archiveClassifier = 'agent'
 
@@ -575,8 +612,10 @@ Bundle-Version: \${project.version}
     }
 
     artifacts {
-        shadowedJar shadowJar.archiveFile
-        archives shadowJar.archiveFile
+        shadowedJar shadowJar
+        archives shadowJar
+        archives agentBundle
+        archives bundle
         archives sourcesJar
         archives javadocJar
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ bndVersion=5.1.2
 modulepluginVersion=1.7.0
 
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g -Dfile.encoding=UTF-8
-org.gradle.caching=true
+org.gradle.caching=false
 org.gradle.daemon=false

--- a/quasar-core/src/main/agent/module-info.java
+++ b/quasar-core/src/main/agent/module-info.java
@@ -1,0 +1,8 @@
+module co.paralleluniverse.quasar.core.agent {
+    requires java.instrument;
+
+    exports co.paralleluniverse.common.asm;
+    exports co.paralleluniverse.common.resource;
+    exports co.paralleluniverse.fibers.instrument;
+}
+

--- a/quasar-core/src/main/bundle/module-info.java
+++ b/quasar-core/src/main/bundle/module-info.java
@@ -1,0 +1,18 @@
+module co.paralleluniverse.quasar.core.osgi {
+    requires java.management;
+    requires jdk.unsupported; // needed for ThreadAccess and ExtendedStackTraceHotSpot
+
+    requires transitive co.paralleluniverse.quasar.core.agent;
+    requires com.google.common;
+
+    exports co.paralleluniverse.fibers;
+    exports co.paralleluniverse.fibers.futures;
+    exports co.paralleluniverse.fibers.io;
+    exports co.paralleluniverse.remote;
+    exports co.paralleluniverse.strands;
+    exports co.paralleluniverse.strands.channels;
+    exports co.paralleluniverse.strands.channels.transfer;
+    exports co.paralleluniverse.strands.concurrent;
+    exports co.paralleluniverse.strands.dataflow;
+}
+

--- a/quasar-core/src/main/java/module-info.java
+++ b/quasar-core/src/main/java/module-info.java
@@ -16,9 +16,9 @@ module co.paralleluniverse.quasar.core {
     requires java.instrument;
     requires jdk.unsupported; // needed for ThreadAccess and ExtendedStackTraceHotSpot
     
-    requires org.objectweb.asm;
-    requires org.objectweb.asm.util;
-    requires org.objectweb.asm.commons;
+    requires static org.objectweb.asm;
+    requires static org.objectweb.asm.util;
+    requires static org.objectweb.asm.commons;
     requires com.google.common;
     requires static kryo;
     requires static ant;


### PR DESCRIPTION
Generate `module-info` files for each Quasar OSGi artifact so that they can participate properly in a modular system.

These replace the unsuitable `module-info` file from the original `quasar-core` artifact.