### PR TITLE
CORE-613: Migrate META-INF/suspendable* files to OSGi agent.

### DIFF
--- a/.ci/dev/Jenkinsfile
+++ b/.ci/dev/Jenkinsfile
@@ -9,7 +9,7 @@ boolean isRelease = (env.TAG_NAME =~ /^release-.*/)
 pipeline {
   agent {
     dockerfile {
-      label 'k8s'
+      label 'standard'
       additionalBuildArgs "--build-arg USER=\$(id -un) --build-arg UID=\$(id -u) --build-arg GID=\$(id -g)"
       filename '.ci/dev/Dockerfile'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -305,7 +305,7 @@ logger.lifecycle("Java target compatibility: {}", targetCompatibility)
 logger.lifecycle("Kotlin version: {}", kotlinVersion)
 logger.lifecycle("Building quasar version: {}", quasarVersion)
 
-def scanAndInstrument(sset, configs) {
+def scanAndInstrument(SourceSet sset, configs) {
 
     def cp = sset.output.classesDirs.getAsPath() + ':' + sset.output.resourcesDir + ':' + configs*.asPath.join(':')
 
@@ -318,7 +318,7 @@ def scanAndInstrument(sset, configs) {
             classpath: cp)
     ant.scanSuspendables(
             auto: false,
-            supersFile:"$sset.output.resourcesDir/META-INF/suspendable-supers",
+            supersFile:"${sset.output.resourcesDir}/META-INF/suspendable-supers",
             append: true) {
         for (File f : sset.output.classesDirs) {
             fileset(dir: f)
@@ -485,12 +485,6 @@ project (':quasar-core') {
         options.compilerArgs += ["--add-modules", "org.objectweb.asm", "--add-reads", "co.paralleluniverse.quasar.core=org.objectweb.asm"]
     }
 
-    configure(project.tasks.compileJava) {
-        doLast {
-            rootProject.scanAndInstrument(sourceSets.main, [configurations.provided, configurations.runtimeClasspath])
-        }
-    }
-
     def shadowJar = tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
         destinationDirectory = file("$buildDir/libs")
         archiveClassifier = ''
@@ -522,6 +516,7 @@ project (':quasar-core') {
     def bundle = tasks.register('bundle', Bundle) {
         dependsOn shadowJar
         from(zipTree(shadowJar.flatMap { it.archiveFile })) {
+            exclude 'META-INF/suspendable*'
             exclude 'co/paralleluniverse/asm/**'
             exclude 'co/paralleluniverse/common/asm/**'
             exclude 'co/paralleluniverse/common/resource/**'
@@ -569,6 +564,7 @@ Import-Package: \
     def agentBundle = tasks.register("agentBundle", Bundle) {
         dependsOn shadowJar
         from(zipTree(shadowJar.flatMap { it.archiveFile })) {
+            include 'META-INF/suspendable*'
             include 'co/paralleluniverse/asm/**'
             include 'co/paralleluniverse/common/asm/**'
             include 'co/paralleluniverse/common/resource/**'

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SimpleSuspendableClassifier.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SimpleSuspendableClassifier.java
@@ -22,11 +22,12 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  *
@@ -94,7 +95,7 @@ public class SimpleSuspendableClassifier implements SuspendableClassifier {
 
     private static void parse(URL file, Set<String> set, Set<String> classSet) {
         try (InputStream is = file.openStream();
-             BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+             BufferedReader reader = new BufferedReader(new InputStreamReader(is, UTF_8))) {
             String line;
 
             for (int linenum = 1; (line = reader.readLine()) != null; linenum++) {
@@ -123,7 +124,7 @@ public class SimpleSuspendableClassifier implements SuspendableClassifier {
         }
     }
 
-    // test if the given method exists expicitly in the suspendables files
+    // test if the given method exists explicitly in the suspendables files
     public boolean isSuspendable(String className, String methodName, String methodDesc) {
         return (suspendables.contains(className + '.' + methodName + methodDesc)
                 || suspendables.contains(className + '.' + methodName)

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SuspendablesScanner.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SuspendablesScanner.java
@@ -138,8 +138,8 @@ public class SuspendablesScanner extends Task {
             log("OUTPUT: " + suspendablesFile, Project.MSG_INFO);
 
             // output results
-            final ArrayList<String> suspendables = suspendablesFile != null ? new ArrayList<String>() : null;
-            final ArrayList<String> suspendableSupers = supersFile != null ? new ArrayList<String>() : null;
+            final List<String> suspendables = suspendablesFile != null ? new ArrayList<>() : null;
+            final List<String> suspendableSupers = supersFile != null ? new ArrayList<>() : null;
             putSuspendablesAndSupers(suspendables, suspendableSupers);
 
             if (suspendablesFile != null) {
@@ -266,9 +266,9 @@ public class SuspendablesScanner extends Task {
     }
 
     private void visitProjectDir(final Function<InputStream, Void> classFileVisitor) throws IOException {
-        Files.walkFileTree(projectDir, new SimpleFileVisitor<Path>() {
+        Files.walkFileTree(projectDir, new SimpleFileVisitor<>() {
             @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                 try {
                     if (isClassFile(file.getFileName().toString()))
                         classFileVisitor.apply(Files.newInputStream(file));
@@ -287,8 +287,7 @@ public class SuspendablesScanner extends Task {
         // scan classes in suspendables file
         if (suspendablesFile != null) {
             SimpleSuspendableClassifier tssc = new SimpleSuspendableClassifier(suspendablesFile);
-            final Set<String> cs = new HashSet<>();
-            cs.addAll(tssc.getSuspendableClasses());
+            final Set<String> cs = new HashSet<>(tssc.getSuspendableClasses());
             for (String susMethod : tssc.getSuspendables())
                 cs.add(susMethod.substring(0, susMethod.indexOf('.')));
 
@@ -506,8 +505,8 @@ public class SuspendablesScanner extends Task {
     }
 
     private void walkGraph() {
-        final Queue<MethodNode> q = new ArrayDeque<>();
-        q.addAll(knownSuspendablesOrSupers); // start the bfs from the manualSusp (all classpath)
+        // start the bfs from the manualSusp (all classpath)
+        final Queue<MethodNode> q = new ArrayDeque<>(knownSuspendablesOrSupers);
 
         while (!q.isEmpty()) {
             final MethodNode m = q.poll();
@@ -715,7 +714,7 @@ public class SuspendablesScanner extends Task {
         }
 
         void setMethods(Collection<String> ms) {
-            this.methods = ms.toArray(new String[ms.size()]);
+            this.methods = ms.toArray(new String[0]);
             for (int i = 0; i < methods.length; i++)
                 methods[i] = methods[i].intern();
         }
@@ -780,27 +779,31 @@ public class SuspendablesScanner extends Task {
             numCallers++;
         }
 
-        @SuppressWarnings("override")
         public Collection<MethodNode> getCallers() {
             if (callers == null)
                 return Collections.emptyList();
             return new AbstractCollection<>() {
+                @Override
                 public int size() {
                     return numCallers;
                 }
 
+                @Override
                 public Iterator<MethodNode> iterator() {
-                    return new Iterator<MethodNode>() {
+                    return new Iterator<>() {
                         private int i;
 
+                        @Override
                         public boolean hasNext() {
                             return i < numCallers;
                         }
 
+                        @Override
                         public MethodNode next() {
                             return callers[i++];
                         }
 
+                        @Override
                         public void remove() {
                             throw new UnsupportedOperationException("remove");
                         }


### PR DESCRIPTION
Move Quasar's built-in lists of suspendables into the instrumentation agent jar, so that they are found immediately even within an OSGi framework.

Also remove Gradle task which generates duplicate suspendables inside `quasar-core`, and fix some compiler warnings.