### PR TITLE
CORE-613: Migrate META-INF/suspendable* files to OSGi agent.

### DIFF
--- a/.ci/dev/Jenkinsfile
+++ b/.ci/dev/Jenkinsfile
@@ -9,7 +9,7 @@ boolean isRelease = (env.TAG_NAME =~ /^release-.*/)
 pipeline {
   agent {
     dockerfile {
-      label 'k8s'
+      label 'standard'
       additionalBuildArgs "--build-arg USER=\$(id -un) --build-arg UID=\$(id -u) --build-arg GID=\$(id -g)"
       filename '.ci/dev/Dockerfile'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -302,7 +302,7 @@ def scanAndInstrument(SourceSet sset, configs) {
         classpath: cp)
     ant.scanSuspendables(
         auto: false,
-        supersFile:"$sset.output.resourcesDir/META-INF/suspendable-supers",
+        supersFile:"${sset.output.resourcesDir}/META-INF/suspendable-supers",
         append: true) {
         for (File f : sset.output.classesDirs) {
             fileset(dir: f)
@@ -426,6 +426,8 @@ project (':quasar-core') {
 
     ssets.each { set ->
         project.tasks.named("compile${capitalize(set.name)}Java", JavaCompile) {
+            // Ensure that the resources output directory has already been created.
+            dependsOn "process${capitalize(set.name)}Resources"
             doLast {
                 rootProject.scanAndInstrument(set, [configurations["${set.name}Runtime"], configurations.provided, configurations.runtimeClasspath])
             }

--- a/build.gradle
+++ b/build.gradle
@@ -289,7 +289,7 @@ subprojects {
     }
 }
 
-def scanAndInstrument(sset, configs) {
+def scanAndInstrument(SourceSet sset, configs) {
 
     def cp = sset.output.classesDirs.getAsPath() + ':' + sset.output.resourcesDir + ':' + configs*.asPath.join(':')
 
@@ -425,7 +425,7 @@ project (':quasar-core') {
     def ssets = [sourceSets.jdk8]
 
     ssets.each { set ->
-        configure(project.tasks["compile${capitalize(set.name)}Java"]) {
+        project.tasks.named("compile${capitalize(set.name)}Java", JavaCompile) {
             doLast {
                 rootProject.scanAndInstrument(set, [configurations["${set.name}Runtime"], configurations.provided, configurations.runtimeClasspath])
             }
@@ -467,6 +467,7 @@ project (':quasar-core') {
         def bundleTask = tasks.register("${set.name}Bundle", Bundle) {
             dependsOn shadowJarTask
             from(zipTree(shadowJarTask.archiveFile)) {
+                exclude 'META-INF/suspendable*'
                 exclude 'co/paralleluniverse/asm/**'
                 exclude 'co/paralleluniverse/common/asm/**'
                 exclude 'co/paralleluniverse/common/resource/**'
@@ -512,6 +513,7 @@ Import-Package: \
         def bundleAgentTask = tasks.register("${set.name}AgentBundle", Bundle) {
             dependsOn shadowJarTask
             from(zipTree(shadowJarTask.archiveFile)) {
+                include 'META-INF/suspendable*'
                 include 'co/paralleluniverse/asm/**'
                 include 'co/paralleluniverse/common/asm/**'
                 include 'co/paralleluniverse/common/resource/**'

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SimpleSuspendableClassifier.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SimpleSuspendableClassifier.java
@@ -21,11 +21,12 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  *
@@ -93,7 +94,7 @@ public class SimpleSuspendableClassifier implements SuspendableClassifier {
 
     private static void parse(URL file, Set<String> set, Set<String> classSet) {
         try (InputStream is = file.openStream();
-             BufferedReader reader = new BufferedReader(new InputStreamReader(is, Charset.forName("UTF-8")))) {
+             BufferedReader reader = new BufferedReader(new InputStreamReader(is, UTF_8))) {
             String line;
 
             for (int linenum = 1; (line = reader.readLine()) != null; linenum++) {
@@ -122,7 +123,7 @@ public class SimpleSuspendableClassifier implements SuspendableClassifier {
         }
     }
 
-    // test if the given method exists expicitly in the suspendables files
+    // test if the given method exists explicitly in the suspendables files
     public boolean isSuspendable(String className, String methodName, String methodDesc) {
         return (suspendables.contains(className + '.' + methodName + methodDesc)
                 || suspendables.contains(className + '.' + methodName)

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SuspendablesScanner.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SuspendablesScanner.java
@@ -137,8 +137,8 @@ public class SuspendablesScanner extends Task {
             log("OUTPUT: " + suspendablesFile, Project.MSG_INFO);
 
             // output results
-            final ArrayList<String> suspendables = suspendablesFile != null ? new ArrayList<String>() : null;
-            final ArrayList<String> suspendableSupers = supersFile != null ? new ArrayList<String>() : null;
+            final List<String> suspendables = suspendablesFile != null ? new ArrayList<>() : null;
+            final List<String> suspendableSupers = supersFile != null ? new ArrayList<>() : null;
             putSuspendablesAndSupers(suspendables, suspendableSupers);
 
             if (suspendablesFile != null) {
@@ -284,8 +284,7 @@ public class SuspendablesScanner extends Task {
         // scan classes in suspendables file
         if (suspendablesFile != null) {
             SimpleSuspendableClassifier tssc = new SimpleSuspendableClassifier(suspendablesFile);
-            final Set<String> cs = new HashSet<>();
-            cs.addAll(tssc.getSuspendableClasses());
+            final Set<String> cs = new HashSet<>(tssc.getSuspendableClasses());
             for (String susMethod : tssc.getSuspendables())
                 cs.add(susMethod.substring(0, susMethod.indexOf('.')));
 
@@ -502,8 +501,8 @@ public class SuspendablesScanner extends Task {
     }
 
     private void walkGraph() {
-        final Queue<MethodNode> q = new ArrayDeque<>();
-        q.addAll(knownSuspendablesOrSupers); // start the bfs from the manualSusp (all classpath)
+        // start the bfs from the manualSusp (all classpath)
+        final Queue<MethodNode> q = new ArrayDeque<>(knownSuspendablesOrSupers);
 
         while (!q.isEmpty()) {
             final MethodNode m = q.poll();
@@ -713,7 +712,7 @@ public class SuspendablesScanner extends Task {
         }
 
         void setMethods(Collection<String> ms) {
-            this.methods = ms.toArray(new String[ms.size()]);
+            this.methods = ms.toArray(new String[0]);
             for (int i = 0; i < methods.length; i++)
                 methods[i] = methods[i].intern();
         }
@@ -778,27 +777,31 @@ public class SuspendablesScanner extends Task {
             numCallers++;
         }
 
-        @SuppressWarnings("override")
         public Collection<MethodNode> getCallers() {
             if (callers == null)
                 return Collections.emptyList();
             return new AbstractCollection<MethodNode>() {
+                @Override
                 public int size() {
                     return numCallers;
                 }
 
+                @Override
                 public Iterator<MethodNode> iterator() {
                     return new Iterator<MethodNode>() {
                         private int i;
 
+                        @Override
                         public boolean hasNext() {
                             return i < numCallers;
                         }
 
+                        @Override
                         public MethodNode next() {
                             return callers[i++];
                         }
 
+                        @Override
                         public void remove() {
                             throw new UnsupportedOperationException("remove");
                         }


### PR DESCRIPTION
Move Quasar's built-in lists of suspendables into the instrumentation agent jar, so that they are found immediately even within an OSGi framework.

Also remove Gradle task which generates duplicate suspendables inside `quasar-core`, and fix some compiler warnings.