### PR TITLE
CORE-902: Prevent DefaultFiberScheduler from registering JMX bean by default.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/DefaultFiberScheduler.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/DefaultFiberScheduler.java
@@ -34,7 +34,6 @@ import java.lang.Thread.UncaughtExceptionHandler;
 public class DefaultFiberScheduler {
     private static final String PROPERTY_PARALLELISM = "co.paralleluniverse.fibers.DefaultFiberPool.parallelism";
     private static final String PROPERTY_EXCEPTION_HANDLER = "co.paralleluniverse.fibers.DefaultFiberPool.exceptionHandler";
-    private static final String PROPERTY_THREAD_FACTORY = "co.paralleluniverse.fibers.DefaultFiberPool.threadFactory";
     private static final String PROPERTY_MONITOR_TYPE = "co.paralleluniverse.fibers.DefaultFiberPool.monitor";
     private static final String PROPERTY_DETAILED_FIBER_INFO = "co.paralleluniverse.fibers.DefaultFiberPool.detailedFiberInfo";
     private static final int MAX_CAP = 0x7fff;  // max #workers - 1
@@ -46,7 +45,7 @@ public class DefaultFiberScheduler {
         int par = 0;
         UncaughtExceptionHandler handler = null;
         // ForkJoinPool.ForkJoinWorkerThreadFactory fac = new NamingForkJoinWorkerFactory(name);
-        MonitorType monitorType = MonitorType.JMX;
+        MonitorType monitorType = null;
         boolean detailedFiberInfo = false;
 
         // get overrides
@@ -74,7 +73,7 @@ public class DefaultFiberScheduler {
 
         String dfis = System.getProperty(PROPERTY_DETAILED_FIBER_INFO);
         if (dfis != null)
-            detailedFiberInfo = Boolean.valueOf(dfis);
+            detailedFiberInfo = Boolean.parseBoolean(dfis);
 
         // build instance
         instance = new FiberForkJoinScheduler(name, par, handler, monitorType, detailedFiberInfo);

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberExecutorScheduler.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberExecutorScheduler.java
@@ -62,6 +62,7 @@ public class FiberExecutorScheduler extends FiberScheduler implements Executor {
         this(name, executor, null, false);
     }
 
+    @Override
     public void shutdown() {
         this.timer.shutdown();
         super.shutdown();

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberScheduler.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberScheduler.java
@@ -33,7 +33,7 @@ public abstract class FiberScheduler implements FiberFactory, StrandFactory {
     static final FibersMonitor NOOP_FIBERS_MONITOR = new NoopFibersMonitor();
     private final String name;
     private final FibersMonitor fibersMonitor;
-    final ConcurrentMap<SchedulerLocal, SchedulerLocal.Entry<?>> schedLocals = new MapMaker().weakKeys().makeMap();
+    final ConcurrentMap<SchedulerLocal<?>, SchedulerLocal.Entry<?>> schedLocals = new MapMaker().weakKeys().makeMap();
 
     FiberScheduler(String name, MonitorType monitorType, boolean detailedInfo) {
         this.name = name;
@@ -68,7 +68,7 @@ public abstract class FiberScheduler implements FiberFactory, StrandFactory {
 
     @Override
     public <T> Fiber<T> newFiber(SuspendableCallable<T> target) {
-        return new Fiber<T>(this, target);
+        return new Fiber<>(this, target);
     }
 
     @Override

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberUtil.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberUtil.java
@@ -67,7 +67,7 @@ public final class FiberUtil {
      * @throws InterruptedException
      */
     public static <V> V runInFiber(FiberScheduler scheduler, SuspendableCallable<V> target) throws ExecutionException, InterruptedException {
-        return new Fiber<V>(scheduler, target).start().get();
+        return new Fiber<>(scheduler, target).start().get();
     }
 
     /**
@@ -123,7 +123,7 @@ public final class FiberUtil {
      */
     public static <V> V runInFiberRuntime(FiberScheduler scheduler, SuspendableCallable<V> target) throws InterruptedException {
         try {
-            return new Fiber<V>(scheduler, target).start().get();
+            return new Fiber<>(scheduler, target).start().get();
         } catch (ExecutionException e) {
             throw Exceptions.rethrow(e.getCause());
         }
@@ -189,7 +189,7 @@ public final class FiberUtil {
      */
     public static <V, X extends Exception> V runInFiberChecked(FiberScheduler scheduler, SuspendableCallable<V> target, Class<X> exceptionType) throws X, InterruptedException {
         try {
-            return new Fiber<V>(scheduler, target).start().get();
+            return new Fiber<>(scheduler, target).start().get();
         } catch (ExecutionException ex) {
             throw throwChecked(ex, exceptionType);
         }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/SchedulerLocal.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/SchedulerLocal.java
@@ -41,7 +41,7 @@ public class SchedulerLocal<T> {
      */
     public final T get() throws SuspendExecution {
         final FiberScheduler scheduler = currentScheduler();
-        final ConcurrentMap<SchedulerLocal, Entry<?>> map = scheduler.schedLocals;
+        final ConcurrentMap<SchedulerLocal<?>, Entry<?>> map = scheduler.schedLocals;
         Entry<T> entry = (Entry<T>) map.get(this);
         if (entry == null) {
             lock.lock();
@@ -75,11 +75,11 @@ public class SchedulerLocal<T> {
         getMap().remove(this);
     }
 
-    private static ConcurrentMap<SchedulerLocal, Entry<?>> getMap() {
+    private static ConcurrentMap<SchedulerLocal<?>, Entry<?>> getMap() {
         return currentScheduler().schedLocals;
     }
 
-    private Entry<T> getEntry(ConcurrentMap<SchedulerLocal, Entry<?>> map) {
+    private Entry<T> getEntry(ConcurrentMap<SchedulerLocal<?>, Entry<?>> map) {
         Entry<T> entry = (Entry<T>) map.get(this);
         if (entry == null) {
             entry = new Entry<>();


### PR DESCRIPTION
`DefaultFiberScheduler` is now an OSGi bundle and not part of the Quasar agent. Therefore it should not automatically register a JMX bean during its `<clinit>` method because this prevents the bundle from being reloaded into the OSGi framework.

Also fix another batch of simple compiler warnings, mostly related to Java generics.