### PR TITLE
NOTICK: Fix errors in JPMS descriptors.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,11 +95,12 @@ subprojects {
         timewarp
         // markdownDoclet
         shadowedJar.extendsFrom runtimeClasspath
+        bundleJar.extendsFrom runtimeClasspath
+        agentJar
 
-        compileClasspath.extendsFrom provided
+        compileOnly.extendsFrom provided
         testCompileOnly.extendsFrom compileOnly
-        testCompileClasspath.extendsFrom provided
-        testRuntimeClasspath.extendsFrom provided
+        testRuntimeOnly.extendsFrom provided
     }
 
     sourceSets {
@@ -122,7 +123,6 @@ subprojects {
             exclude group: 'org.checkerframework', module: 'checker-qual'
         }
         timewarp 'co.paralleluniverse:timewarp:0.2.0-SNAPSHOT'
-        testImplementation 'co.paralleluniverse:timewarp:0.2.0-SNAPSHOT'
         testImplementation 'org.hamcrest:hamcrest-all:1.3'
         testImplementation('junit:junit:4.12') {
             exclude group: 'org.hamcrest', module: '*'
@@ -385,13 +385,6 @@ project (':quasar-core') {
 
     ext.moduleName = 'co.paralleluniverse.quasar.core'
     
-    // remove default artifact
-    configurations.runtimeClasspath.artifacts.with { archives ->
-        archives.each {
-            archives.remove(it)
-        }
-    }
-
     sourceSets {
         main {
             java {
@@ -437,7 +430,6 @@ project (':quasar-core') {
     }
 
     configurations {
-        compileClasspath.extendsFrom provided
         bundleImplementation.extendsFrom implementation
         bundleImplementation.extendsFrom agentImplementation
     }
@@ -630,8 +622,10 @@ Bundle-Version: \${project.version}
     artifacts {
         shadowedJar shadowJar
         archives shadowJar
-        archives agentBundle
+        bundleJar bundle
         archives bundle
+        agentJar agentBundle
+        archives agentBundle
         archives sourcesJar
         archives javadocJar
     }
@@ -784,8 +778,6 @@ clean {
         delete 'docs/javadoc'
     }
 }
-
-def capitalize(s) { s[0].toUpperCase() + s[1..-1].toLowerCase() }
 
 def publishedProjects = subprojects
 

--- a/quasar-core/src/main/agent/module-info.java
+++ b/quasar-core/src/main/agent/module-info.java
@@ -6,6 +6,6 @@ module co.paralleluniverse.quasar.core.agent {
     exports co.paralleluniverse.fibers.instrument;
     exports co.paralleluniverse.fibers.suspend;
 
-    opens co.paralleluniverse.fibers.suspend to co.paralleluniverse.fibers;
+    opens co.paralleluniverse.fibers.suspend to co.paralleluniverse.quasar.core.osgi;
 }
 

--- a/quasar-core/src/main/bundle/module-info.java
+++ b/quasar-core/src/main/bundle/module-info.java
@@ -5,6 +5,11 @@ module co.paralleluniverse.quasar.core.osgi {
     requires transitive co.paralleluniverse.quasar.core.agent;
     requires com.google.common;
 
+    // These are "automatic" module names, so keep them hidden!
+    requires static kryo;
+    requires static kryo.serializers;
+    requires static objenesis;
+
     exports co.paralleluniverse.fibers;
     exports co.paralleluniverse.fibers.futures;
     exports co.paralleluniverse.fibers.io;

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SimpleSuspendableClassifier.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SimpleSuspendableClassifier.java
@@ -131,7 +131,7 @@ public class SimpleSuspendableClassifier implements SuspendableClassifier {
                 || suspendableClasses.contains(className));
     }
 
-    // test if the given method exists expicitly in the super-suspendable files
+    // test if the given method exists explicitly in the super-suspendable files
     public boolean isSuperSuspendable(String className, String methodName, String methodDesc) {
         return (suspendableSupers.contains(className + '.' + methodName + methodDesc)
                 || suspendableSupers.contains(className + '.' + methodName)

--- a/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/ExternalizableKryoSerializer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/ExternalizableKryoSerializer.java
@@ -13,6 +13,7 @@
 package co.paralleluniverse.io.serialization.kryo;
 
 import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import java.io.Externalizable;
@@ -22,9 +23,7 @@ import java.io.IOException;
  *
  * @author pron
  */
-public class ExternalizableKryoSerializer<T extends Externalizable> extends com.esotericsoftware.kryo.Serializer<T> {
-    private static final KryoSerializer ks = new KryoSerializer();
-    
+public class ExternalizableKryoSerializer<T extends Externalizable> extends Serializer<T> {
     @Override
     public void write(Kryo kryo, Output output, T obj) {
         try {

--- a/quasar-core/src/main/java/module-info.java
+++ b/quasar-core/src/main/java/module-info.java
@@ -21,6 +21,8 @@ module co.paralleluniverse.quasar.core {
     requires static org.objectweb.asm.commons;
     requires com.google.common;
     requires static kryo;
+    requires static kryo.serializers;
+    requires static objenesis;
     requires static ant;
     requires static junit;
     requires static HdrHistogram;
@@ -54,8 +56,6 @@ module co.paralleluniverse.quasar.core {
     // co.paralleluniverse.asm is actually a shadowing of org.objectweb.asm.
     exports co.paralleluniverse.asm to co.paralleluniverse.quasar.actors;
     exports co.paralleluniverse.common.asm to co.paralleluniverse.quasar.actors;
-
-    opens co.paralleluniverse.fibers.suspend to co.paralleluniverse.fibers;
 
     uses co.paralleluniverse.fibers.instrument.SuspendableClassifier;
 }

--- a/quasar-kotlin/build.gradle
+++ b/quasar-kotlin/build.gradle
@@ -18,13 +18,12 @@ configurations.all {
 
 dependencies {
     implementation project(path: ':quasar-core', configuration: 'shadowedJar')
-    implementation project(':quasar-actors')
+    implementation(project(':quasar-actors')) {
+        exclude module: 'quasar-core'
+    }
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-
-    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
 }
 
 sourceSets {

--- a/quasar-kotlin/src/AnnotationTest/kotlin/co/paralleluniverse/kotlin/fibers/AnnotationTest.kt
+++ b/quasar-kotlin/src/AnnotationTest/kotlin/co/paralleluniverse/kotlin/fibers/AnnotationTest.kt
@@ -2,10 +2,9 @@ package co.paralleluniverse.kotlin.fibers
 
 import co.paralleluniverse.common.util.SystemProperties
 import co.paralleluniverse.fibers.Fiber
-
-import org.junit.Assume
+import org.junit.Assert.assertEquals
+import org.junit.Assume.assumeTrue
 import org.junit.Test
-import kotlin.test.assertEquals
 
 class AnnotationTest {
 
@@ -19,10 +18,10 @@ class AnnotationTest {
     }
 
     @Test
-    fun `Simple MySuspendable annotation`() {
+    fun `simple MySuspendable annotation`() {
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Int>() {
                 @MySuspendable
@@ -37,10 +36,10 @@ class AnnotationTest {
     }
 
     @Test
-    fun `Simple DennisSuspendable annotation`() {
+    fun `simple DennisSuspendable annotation`() {
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Int>() {
                 @DennisSuspendable
@@ -55,10 +54,10 @@ class AnnotationTest {
     }
 
     @Test
-    fun `Simple MySuspendable, DennisSuspendable annotation`() {
+    fun `simple MySuspendable, DennisSuspendable annotation`() {
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Int>() {
                 @DennisSuspendable

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/StaticPropertiesTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/StaticPropertiesTest.kt
@@ -1,22 +1,22 @@
 package co.paralleluniverse.kotlin.fibers
 
 import co.paralleluniverse.common.util.SystemProperties
-import co.paralleluniverse.fibers.Fiber;
+import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
-import org.junit.Assume
+import org.junit.Assume.assumeTrue
 
 object StaticPropertiesTest {
 
     const val verifyInstrumentationKey = "co.paralleluniverse.fibers.verifyInstrumentation"
 
     fun <T> withVerifyInstrumentationOn(statement: () -> T): T {
-        return withKey(verifyInstrumentationKey, statement);
+        return withKey(verifyInstrumentationKey, statement)
     }
 
     fun <T> withKey(key : String, statement: () -> T): T{
         val originalValue = System.getProperty(key)
         System.setProperty(key, "true")
-        Fiber.readSystemProperties();
+        Fiber.readSystemProperties()
         try {
             return statement()
         } finally {
@@ -25,13 +25,13 @@ object StaticPropertiesTest {
             } else {
                 System.setProperty(key, originalValue)
             }
-            Fiber.readSystemProperties();
+            Fiber.readSystemProperties()
         }
     }
 
     fun <T> fiberWithVerifyInstrumentationOn(f: () -> T) : T {
         return withVerifyInstrumentationOn {
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(verifyInstrumentationKey))
             val fiber = object : Fiber<T>() {
                 @Suspendable
                 override fun run(): T {

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/AbstractTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/AbstractTest.kt
@@ -3,11 +3,10 @@ package co.paralleluniverse.kotlin.fibers.lang
 import co.paralleluniverse.common.util.SystemProperties
 import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
-import org.junit.Assume
-import org.junit.Test
-import kotlin.test.assertEquals
-
 import co.paralleluniverse.kotlin.fibers.StaticPropertiesTest
+import org.junit.Assert.assertEquals
+import org.junit.Assume.assumeTrue
+import org.junit.Test
 
 abstract class AbstractClass  {
 
@@ -18,7 +17,7 @@ abstract class AbstractClass  {
         return if (b) {
             m
         } else {
-            mapOf<Int, Int>(6 to 7)
+            mapOf(6 to 7)
         }
     }
 
@@ -43,7 +42,7 @@ class ConcreteClass : AbstractClass() {
         return if (b) {
             m
         } else {
-            mapOf<Int, Int>(1 to 1)
+            mapOf(1 to 1)
         }
     }
 
@@ -61,7 +60,7 @@ class AbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Int>() {
                 val ac : AbstractClass = ConcreteClass()
@@ -80,7 +79,7 @@ class AbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Int>() {
                 val ac : AbstractClass = ConcreteClass()
@@ -99,7 +98,7 @@ class AbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<MyMap>() {
                 val ac : AbstractClass = ConcreteClass()
@@ -118,7 +117,7 @@ class AbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<MyMap>() {
                 val ac : AbstractClass = ConcreteClass()

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/FunTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/FunTest.kt
@@ -54,63 +54,63 @@ class FunTest {
     val scheduler = FiberForkJoinScheduler("test", 4, null, false)
 
     @Test fun testSimpleFun() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable @Suspendable {
             f()
             true
         }).start().get())
     }
 
     @Test fun testDefaultFunWithAllArgs() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable @Suspendable {
             fDef(true)
             true
         }).start().get())
     }
 
     @Test fun testDefaultFunWithoutSomeArgs() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable @Suspendable {
             fDef()
             true
         }).start().get())
     }
 
     @Test fun testQuickFun() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable @Suspendable {
             fQuick()
             true
         }).start().get())
     }
 
     @Test fun testVarArgFun0() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable @Suspendable {
             fVarArg()
             true
         }).start().get())
     }
 
     @Test fun testVarArgFun1() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable @Suspendable {
             fVarArg(10)
             true
         }).start().get())
     }
 
     @Test fun testFunRefInvoke() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable @Suspendable {
             (::fQuick)()
             true
         }).start().get())
     }
 
     @Test fun testFunRefArg() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable @Suspendable {
             seq(::fQuick, ::fQuick)()
             true
         }).start().get())
     }
 
     @Test fun testFunLambda() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable @Suspendable {
             (@Suspendable { _ : Int -> Fiber.sleep(10) })(1)
             true
         }).start().get())
@@ -126,7 +126,7 @@ class FunTest {
     @Test fun testFunLambda2() = assertTrue(callSusLambda(@Suspendable { Fiber.sleep(10) }, 1))
 
     @Test fun testFunAnon() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable @Suspendable {
             (@Suspendable fun(_ : Int) { Fiber.sleep(10) })(1)
             true
         }).start().get())

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/MethodOverloadTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/MethodOverloadTest.kt
@@ -17,10 +17,9 @@ import co.paralleluniverse.common.util.SystemProperties
 import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.kotlin.fibers.StaticPropertiesTest
-
-import org.junit.Assume
+import org.junit.Assert.assertNotNull
+import org.junit.Assume.assumeTrue
 import org.junit.Test
-import kotlin.test.assertNotNull
 
 class MethodOverloadTest {
 
@@ -37,7 +36,7 @@ class MethodOverloadTest {
     @Test fun methodOverloadTest() {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Any>() {
                 @Suspendable

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/OOTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/OOTest.kt
@@ -17,10 +17,10 @@ import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.FiberForkJoinScheduler
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.strands.SuspendableCallable
-import org.junit.Assert.assertTrue
-import org.junit.Test
 import kotlin.reflect.KProperty
-import kotlin.test.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Test
 
 
 /**

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/SyntheticAbstractTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/SyntheticAbstractTest.kt
@@ -3,11 +3,10 @@ package co.paralleluniverse.kotlin.fibers.lang
 import co.paralleluniverse.common.util.SystemProperties
 import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
-import org.junit.Assume
-import org.junit.Test
-import kotlin.test.assertEquals
-
 import co.paralleluniverse.kotlin.fibers.StaticPropertiesTest
+import org.junit.Assert.assertEquals
+import org.junit.Assume.assumeTrue
+import org.junit.Test
 
 abstract class SyntheticAbstractClass  {
 
@@ -61,7 +60,7 @@ class SyntheticAbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Int>() {
                 val ac : SyntheticAbstractClass = SyntheticConcreteClass()
@@ -80,7 +79,7 @@ class SyntheticAbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Int>() {
                 val ac : SyntheticAbstractClass = SyntheticConcreteClass()
@@ -99,7 +98,7 @@ class SyntheticAbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<MyMap>() {
                 val ac : SyntheticAbstractClass = SyntheticConcreteClass()
@@ -118,7 +117,7 @@ class SyntheticAbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<MyMap>() {
                 val ac : SyntheticAbstractClass = SyntheticConcreteClass()

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/SyntheticTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/SyntheticTest.kt
@@ -3,11 +3,10 @@ package co.paralleluniverse.kotlin.fibers.lang
 import co.paralleluniverse.common.util.SystemProperties
 import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
-import org.junit.Assume
-import org.junit.Test
-import kotlin.test.assertEquals
-
 import co.paralleluniverse.kotlin.fibers.StaticPropertiesTest
+import org.junit.Assert.assertEquals
+import org.junit.Assume.assumeTrue
+import org.junit.Test
 
 typealias MyMap = Map<Int, Int>
 
@@ -37,7 +36,7 @@ class SyntheticTest {
     private fun defFun() : Int {
         return  defFun1() + defFun1(10) +
                 defFun2(4) + defFun2(4,2) +
-                defFun3() + defFun3(4) + defFun3(6,1);
+                defFun3() + defFun3(4) + defFun3(6,1)
     }
 
     @Suspendable
@@ -46,15 +45,15 @@ class SyntheticTest {
         return if (b) {
             m
         } else {
-            mapOf<Int, Int>(1 to 3)
+            mapOf(1 to 3)
         }
     }
 
-    @Test fun `synthetic primitve`() {
+    @Test fun `synthetic primitive`() {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Any>() {
                 @Suspendable
@@ -71,7 +70,7 @@ class SyntheticTest {
     @Test fun `synthetic complex`() {
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<MyMap>() {
                 @Suspendable
@@ -87,7 +86,7 @@ class SyntheticTest {
     @Test fun `synthetic complex default`() {
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<MyMap>() {
                 @Suspendable

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/_1_4_x/BreakContinueTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/_1_4_x/BreakContinueTest.kt
@@ -3,8 +3,8 @@ package co.paralleluniverse.kotlin.fibers.lang._1_4_x
 import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.kotlin.fibers.StaticPropertiesTest
 import co.paralleluniverse.fibers.Suspendable
+import org.junit.Assert.assertEquals
 import org.junit.Test
-import kotlin.test.assertEquals
 
 class BreakContinueTest {
 

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/_1_4_x/CallableReference.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/_1_4_x/CallableReference.kt
@@ -1,12 +1,10 @@
 package co.paralleluniverse.kotlin.fibers.lang._1_4_x
 
-import co.paralleluniverse.common.util.SystemProperties
 import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.kotlin.fibers.StaticPropertiesTest.fiberWithVerifyInstrumentationOn
-import org.junit.Assume
+import org.junit.Assert.assertEquals
 import org.junit.Test
-import kotlin.test.assertEquals
 
 class CallableReference {
 
@@ -17,7 +15,7 @@ class CallableReference {
 
     @Suspendable
     private fun def1(a0:Int=0, s0: String="hello") : String {
-        doYield();
+        doYield()
         return if (a0 > 0) {s0} else {"wow"}
     }
 

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/_1_4_x/LambdaTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/_1_4_x/LambdaTest.kt
@@ -3,10 +3,10 @@ package co.paralleluniverse.kotlin.fibers.lang._1_4_x
 import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.kotlin.fibers.StaticPropertiesTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class LambdaTest {
 

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/_1_4_x/NameAndPositionalArgumentsTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/_1_4_x/NameAndPositionalArgumentsTest.kt
@@ -1,15 +1,10 @@
 package co.paralleluniverse.kotlin.fibers.lang._1_4_x
 
-import co.paralleluniverse.common.util.SystemProperties
 import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.kotlin.fibers.StaticPropertiesTest.fiberWithVerifyInstrumentationOn
-import org.junit.Assume
-import org.junit.Ignore
+import org.junit.Assert.assertEquals
 import org.junit.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class NameAndPositionalArgumentsTest {
 

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/_1_4_x/SAMTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/_1_4_x/SAMTest.kt
@@ -1,15 +1,11 @@
 package co.paralleluniverse.kotlin.fibers.lang._1_4_x
 
-import co.paralleluniverse.common.util.SystemProperties
 import co.paralleluniverse.fibers.Fiber
-import co.paralleluniverse.fibers.Fiber.sleep
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.kotlin.fibers.StaticPropertiesTest.fiberWithVerifyInstrumentationOn
-import org.junit.Assume
-import org.junit.Ignore
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class SAMTest {
 
@@ -34,13 +30,13 @@ class SAMTest {
 
     @Suspendable
     fun localSAM(a:Int) : Boolean {
-        val isPositive = IntPredicate @Suspendable{ Fiber.yield(); it > 0}
+        val isPositive = IntPredicate @Suspendable{ Fiber.yield(); it > 0 }
         return isPositive.accept(a)
     }
 
     @Test fun `local lambdas`(){
         // This lambda will be instrumented !!
-        assertTrue { { num: Int -> num > 0}(5) }
+        assertTrue({ num: Int -> num > 0 }(5))
     }
 
     @Test fun `local lambdas in suspendables`() {

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/stdlib/StdDelegates.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/stdlib/StdDelegates.kt
@@ -18,10 +18,10 @@ import co.paralleluniverse.fibers.FiberForkJoinScheduler
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.kotlin.quasarLazy
 import co.paralleluniverse.strands.SuspendableCallable
-import org.junit.Assert
-import org.junit.Test
 import kotlin.properties.Delegates
-import kotlin.test.assertNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
 
 /**
  * @author circlespainter
@@ -34,7 +34,7 @@ class StdDelegates {
             Fiber.sleep(1)
             true
         }
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ipLazySync
         }).start().get())
     }
@@ -45,7 +45,7 @@ class StdDelegates {
     }
 
     @Test fun testValLazySyncDelegProp() {
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ipLazySync
         }).start().get())
     }
@@ -55,7 +55,7 @@ class StdDelegates {
             Fiber.sleep(1)
             true
         }
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ipLazyPub
         }).start().get())
     }
@@ -66,7 +66,7 @@ class StdDelegates {
     }
 
     @Test fun testValLazyPubDelegProp() {
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ipLazyPub
         }).start().get())
     }
@@ -76,7 +76,7 @@ class StdDelegates {
             Fiber.sleep(1)
             true
         }
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ipLazyNone
         }).start().get())
     }
@@ -87,7 +87,7 @@ class StdDelegates {
     }
 
     @Test fun testValLazyUnsafeDelegProp() {
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ipLazyNone
         }).start().get())
     }
@@ -98,7 +98,7 @@ class StdDelegates {
             Fiber.sleep(1)
             println("$old -> $new")
         }
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ivObs
         }).start().get())
     }
@@ -110,7 +110,7 @@ class StdDelegates {
     }
 
     @Test fun testValObservableDelegProp() {
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ivObs
         }).start().get())
     }
@@ -133,7 +133,7 @@ class StdDelegates {
             Fiber.sleep(1)
             println("$old -> $new")
         }
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             mvObs = true
             mvObs
         }).start().get())
@@ -152,7 +152,7 @@ class StdDelegates {
     }
 
     @Test fun testVarObservableSetDelegProp() {
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             mvObs = true
             mvObs
         }).start().get())


### PR DESCRIPTION
- The correct syntax for JPMS `opens` is "opens package to module".
- Kryo only has "automatic" module names, which cannot safely be used at runtime. Ensure they're only used for compiling.
- Remove unused `static final` field from `ExternalizableKryoSerializer`.
- Fix some spelling errors and compiler warnings.
- Remove some more Gradle cruft.
- Tidy up more imports.