### PR TITLE
NOTICK: Backport cruft removal from release/0.8 branch.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,9 +89,9 @@ subprojects {
         timewarp
         // markdownDoclet
 
-        compileClasspath.extendsFrom provided
-        testCompileClasspath.extendsFrom provided
-        testRuntimeClasspath.extendsFrom provided
+        compileOnly.extendsFrom provided
+        testCompileOnly.extendsFrom compileOnly
+        testRuntimeOnly.extendsFrom provided
     }
 
     sourceSets {
@@ -114,7 +114,6 @@ subprojects {
         provided "org.apache.ant:ant:1.9.9" // version 1.10 and upwards requires JDK 8
         implementation "com.google.guava:guava:20.0" // version 21.0 and upwards requires JDK 8
         timewarp 'co.paralleluniverse:timewarp:0.1.0-SNAPSHOT'
-        testImplementation 'co.paralleluniverse:timewarp:0.1.0-SNAPSHOT'
         testImplementation 'junit:junit:4.12'
         testImplementation('com.google.truth:truth:0.34') {
             exclude group: 'com.google.guava', module: 'guava'
@@ -398,7 +397,6 @@ project (':quasar-core') {
     }
 
     configurations {
-        compileClasspath.extendsFrom provided
         jdk8Archives.extendsFrom runtimeClasspath
     }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SimpleSuspendableClassifier.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SimpleSuspendableClassifier.java
@@ -130,7 +130,7 @@ public class SimpleSuspendableClassifier implements SuspendableClassifier {
                 || suspendableClasses.contains(className));
     }
 
-    // test if the given method exists expicitly in the super-suspendable files
+    // test if the given method exists explicitly in the super-suspendable files
     public boolean isSuperSuspendable(String className, String methodName, String methodDesc) {
         return (suspendableSupers.contains(className + '.' + methodName + methodDesc)
                 || suspendableSupers.contains(className + '.' + methodName)

--- a/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/ExternalizableKryoSerializer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/ExternalizableKryoSerializer.java
@@ -13,6 +13,7 @@
 package co.paralleluniverse.io.serialization.kryo;
 
 import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import java.io.Externalizable;
@@ -22,9 +23,7 @@ import java.io.IOException;
  *
  * @author pron
  */
-public class ExternalizableKryoSerializer<T extends Externalizable> extends com.esotericsoftware.kryo.Serializer<T> {
-    private static final KryoSerializer ks = new KryoSerializer();
-    
+public class ExternalizableKryoSerializer<T extends Externalizable> extends Serializer<T> {
     @Override
     public void write(Kryo kryo, Output output, T obj) {
         try {

--- a/quasar-kotlin/build.gradle
+++ b/quasar-kotlin/build.gradle
@@ -7,13 +7,12 @@ targetCompatibility = '1.8'
 
 dependencies {
     implementation project(path: ':quasar-core', configuration: 'jdk8Archives')
-    implementation project(':quasar-actors')
+    implementation(project(':quasar-actors')) {
+        exclude module: 'quasar-core'
+    }
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinTestVersion"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinTestVersion"
-
-    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinTestVersion"
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinTestVersion"
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/actors/PingPongWithDefer.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/actors/PingPongWithDefer.kt
@@ -22,7 +22,7 @@ import co.paralleluniverse.kotlin.register
 import co.paralleluniverse.kotlin.spawn
 import org.junit.Test
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Date
 import java.util.concurrent.TimeUnit.SECONDS
 
 /**

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/FiberAsyncTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/FiberAsyncTest.kt
@@ -243,7 +243,7 @@ class FiberAsyncTest {
     @Test
     fun testRunBlocking() {
         val fiber = Fiber<Void>(scheduler, SuspendableRunnable @Suspendable {
-            val res = FiberAsync.runBlocking(Executors.newCachedThreadPool(), CheckedCallable<kotlin.String, java.lang.InterruptedException> @Suspendable {
+            val res = FiberAsync.runBlocking(Executors.newCachedThreadPool(), CheckedCallable<String, InterruptedException> @Suspendable {
                 Strand.sleep(300)
                 "ok"
             })
@@ -257,7 +257,7 @@ class FiberAsyncTest {
     fun testRunBlockingWithTimeout1() {
         val fiber = Fiber<Void>(scheduler, SuspendableRunnable @Suspendable {
             try {
-                val res = FiberAsync.runBlocking(Executors.newCachedThreadPool(), 400, TimeUnit.MILLISECONDS, CheckedCallable<kotlin.String, java.lang.InterruptedException> @Suspendable {
+                val res = FiberAsync.runBlocking(Executors.newCachedThreadPool(), 400, TimeUnit.MILLISECONDS, CheckedCallable<String, InterruptedException> @Suspendable {
                     Strand.sleep(300)
                     "ok"
                 })
@@ -274,7 +274,7 @@ class FiberAsyncTest {
     fun testRunBlockingWithTimeout2() {
         val fiber = Fiber<Void>(SuspendableRunnable @Suspendable {
             try {
-                FiberAsync.runBlocking(Executors.newCachedThreadPool(), 100, TimeUnit.MILLISECONDS, CheckedCallable<kotlin.String, java.lang.InterruptedException> @Suspendable {
+                FiberAsync.runBlocking(Executors.newCachedThreadPool(), 100, TimeUnit.MILLISECONDS, CheckedCallable<String, InterruptedException> @Suspendable {
                     Strand.sleep(300)
                     "ok"
                 })

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/FiberKotlinTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/FiberKotlinTest.kt
@@ -13,13 +13,15 @@
  */
 package co.paralleluniverse.kotlin.fibers
 
-import co.paralleluniverse.kotlin.*
+import co.paralleluniverse.kotlin.Receive
+import co.paralleluniverse.kotlin.Send
+import co.paralleluniverse.kotlin.fiber
+import co.paralleluniverse.kotlin.select
 import co.paralleluniverse.strands.Strand
 import co.paralleluniverse.strands.channels.Channels
-
-import org.junit.Test
-import org.junit.Assert.*
 import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertTrue
+import org.junit.Test
 
 /**
  * @author circlespainter
@@ -80,7 +82,7 @@ class FiberKotlinTest {
     return f()
   }
 
-  private fun dumpStack() : Unit {
+  private fun dumpStack() {
     Throwable().printStackTrace()
   }
 }

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/StaticPropertiesTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/StaticPropertiesTest.kt
@@ -1,19 +1,19 @@
 package co.paralleluniverse.kotlin.fibers
 
-import co.paralleluniverse.fibers.Fiber;
+import co.paralleluniverse.fibers.Fiber
 
 object StaticPropertiesTest {
 
     const val verifyInstrumentationKey = "co.paralleluniverse.fibers.verifyInstrumentation"
 
     fun <T> withVerifyInstrumentationOn(statement: () -> T): T {
-        return withKey(verifyInstrumentationKey, statement);
+        return withKey(verifyInstrumentationKey, statement)
     }
 
     fun <T> withKey(key : String, statement: () -> T): T{
         val originalValue = System.getProperty(key)
         System.setProperty(key, "true")
-        Fiber.readSystemProperties();
+        Fiber.readSystemProperties()
         try {
             return statement()
         } finally {
@@ -22,7 +22,7 @@ object StaticPropertiesTest {
             } else {
                 System.setProperty(key, originalValue)
             }
-            Fiber.readSystemProperties();
+            Fiber.readSystemProperties()
         }
     }
 

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/AbstractTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/AbstractTest.kt
@@ -16,11 +16,10 @@ package co.paralleluniverse.kotlin.fibers.lang
 import co.paralleluniverse.common.util.SystemProperties
 import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
-import org.junit.Assume
-import org.junit.Test
-import kotlin.test.assertEquals
-
 import co.paralleluniverse.kotlin.fibers.StaticPropertiesTest
+import org.junit.Assert.assertEquals
+import org.junit.Assume.assumeTrue
+import org.junit.Test
 
 abstract class AbstractClass  {
 
@@ -31,7 +30,7 @@ abstract class AbstractClass  {
         return if (b) {
             m
         } else {
-            mapOf<Int, Int>(6 to 7)
+            mapOf(6 to 7)
         }
     }
 
@@ -56,7 +55,7 @@ class ConcreteClass : AbstractClass() {
         return if (b) {
             m
         } else {
-            mapOf<Int, Int>(1 to 1)
+            mapOf(1 to 1)
         }
     }
 
@@ -74,7 +73,7 @@ class AbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Int>() {
                 val ac : AbstractClass = ConcreteClass()
@@ -93,7 +92,7 @@ class AbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Int>() {
                 val ac : AbstractClass = ConcreteClass()
@@ -112,7 +111,7 @@ class AbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<MyMap>() {
                 val ac : AbstractClass = ConcreteClass()
@@ -131,7 +130,7 @@ class AbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<MyMap>() {
                 val ac : AbstractClass = ConcreteClass()

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/FunTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/FunTest.kt
@@ -54,63 +54,63 @@ class FunTest {
     val scheduler = FiberForkJoinScheduler("test", 4, null, false)
 
     @Test fun testSimpleFun() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             f()
             true
         }).start().get())
     }
 
     @Test fun testDefaultFunWithAllArgs() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             fDef(true)
             true
         }).start().get())
     }
 
     @Test fun testDefaultFunWithoutSomeArgs() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             fDef()
             true
         }).start().get())
     }
 
     @Test fun testQuickFun() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             fQuick()
             true
         }).start().get())
     }
 
     @Test fun testVarArgFun0() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             fVarArg()
             true
         }).start().get())
     }
 
     @Test fun testVarArgFun1() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             fVarArg(10)
             true
         }).start().get())
     }
 
     @Test fun testFunRefInvoke() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             (::fQuick)()
             true
         }).start().get())
     }
 
     @Test fun testFunRefArg() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             seq(::fQuick, ::fQuick)()
             true
         }).start().get())
     }
 
     @Test fun testFunLambda() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             (@Suspendable { _ : Int -> Fiber.sleep(10) })(1)
             true
         }).start().get())
@@ -126,7 +126,7 @@ class FunTest {
     @Test fun testFunLambda2() = assertTrue(callSusLambda(@Suspendable { Fiber.sleep(10) }, 1))
 
     @Test fun testFunAnon() {
-        assertTrue(Fiber(scheduler, SuspendableCallable<kotlin.Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             (@Suspendable fun(_ : Int) { Fiber.sleep(10) })(1)
             true
         }).start().get())

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/MethodOverloadTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/MethodOverloadTest.kt
@@ -17,10 +17,9 @@ import co.paralleluniverse.common.util.SystemProperties
 import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.kotlin.fibers.StaticPropertiesTest
-
-import org.junit.Assume
+import org.junit.Assert.assertNotNull
+import org.junit.Assume.assumeTrue
 import org.junit.Test
-import kotlin.test.assertNotNull
 
 class MethodOverloadTest {
 
@@ -37,7 +36,7 @@ class MethodOverloadTest {
     @Test fun methodOverloadTest() {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Any>() {
                 @Suspendable

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/OOTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/OOTest.kt
@@ -17,12 +17,11 @@ import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.FiberForkJoinScheduler
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.strands.SuspendableCallable
+import kotlin.reflect.KProperty
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Ignore
 import org.junit.Test
-import kotlin.reflect.KProperty
-import kotlin.test.assertFalse
-
 
 /**
  * @author circlespainter

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/SyntheticAbstractTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/SyntheticAbstractTest.kt
@@ -16,11 +16,10 @@ package co.paralleluniverse.kotlin.fibers.lang
 import co.paralleluniverse.common.util.SystemProperties
 import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
-import org.junit.Assume
-import org.junit.Test
-import kotlin.test.assertEquals
-
 import co.paralleluniverse.kotlin.fibers.StaticPropertiesTest
+import org.junit.Assert.assertEquals
+import org.junit.Assume.assumeTrue
+import org.junit.Test
 
 abstract class SyntheticAbstractClass  {
 
@@ -31,7 +30,7 @@ abstract class SyntheticAbstractClass  {
         return if (b) {
             m
         } else {
-            mapOf<Int, Int>(6 to 7)
+            mapOf(6 to 7)
         }
     }
 
@@ -56,7 +55,7 @@ class SyntheticConcreteClass : SyntheticAbstractClass() {
         return if (b) {
             m
         } else {
-            mapOf<Int, Int>(1 to 1)
+            mapOf(1 to 1)
         }
     }
 
@@ -74,7 +73,7 @@ class SyntheticAbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Int>() {
                 val ac : SyntheticAbstractClass = SyntheticConcreteClass()
@@ -93,7 +92,7 @@ class SyntheticAbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Int>() {
                 val ac : SyntheticAbstractClass = SyntheticConcreteClass()
@@ -112,7 +111,7 @@ class SyntheticAbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<MyMap>() {
                 val ac : SyntheticAbstractClass = SyntheticConcreteClass()
@@ -131,7 +130,7 @@ class SyntheticAbstractTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<MyMap>() {
                 val ac : SyntheticAbstractClass = SyntheticConcreteClass()

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/SyntheticTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/SyntheticTest.kt
@@ -16,11 +16,10 @@ package co.paralleluniverse.kotlin.fibers.lang
 import co.paralleluniverse.common.util.SystemProperties
 import co.paralleluniverse.fibers.Fiber
 import co.paralleluniverse.fibers.Suspendable
-import org.junit.Assume
-import org.junit.Test
-import kotlin.test.assertEquals
-
 import co.paralleluniverse.kotlin.fibers.StaticPropertiesTest
+import org.junit.Assert.assertEquals
+import org.junit.Assume.assumeTrue
+import org.junit.Test
 
 typealias MyMap = Map<Int, Int>
 
@@ -50,7 +49,7 @@ class SyntheticTest {
     private fun defFun() : Int {
         return  defFun1() + defFun1(10) +
                 defFun2(4) + defFun2(4,2) +
-                defFun3() + defFun3(4) + defFun3(6,1);
+                defFun3() + defFun3(4) + defFun3(6,1)
     }
 
     @Suspendable
@@ -59,7 +58,7 @@ class SyntheticTest {
         return if (b) {
             m
         } else {
-            mapOf<Int, Int>(1 to 3)
+            mapOf(1 to 3)
         }
     }
 
@@ -67,7 +66,7 @@ class SyntheticTest {
 
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<Any>() {
                 @Suspendable
@@ -84,7 +83,7 @@ class SyntheticTest {
     @Test fun `synthetic complex`() {
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<MyMap>() {
                 @Suspendable
@@ -100,7 +99,7 @@ class SyntheticTest {
     @Test fun `synthetic complex default`() {
         StaticPropertiesTest.withVerifyInstrumentationOn {
 
-            Assume.assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
+            assumeTrue(SystemProperties.isEmptyOrTrue(StaticPropertiesTest.verifyInstrumentationKey))
 
             val fiber = object : Fiber<MyMap>() {
                 @Suspendable

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/stdlib/StdDelegates.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/stdlib/StdDelegates.kt
@@ -18,10 +18,10 @@ import co.paralleluniverse.fibers.FiberForkJoinScheduler
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.kotlin.quasarLazy
 import co.paralleluniverse.strands.SuspendableCallable
-import org.junit.Assert
-import org.junit.Test
 import kotlin.properties.Delegates
-import kotlin.test.assertNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
 
 /**
  * @author circlespainter
@@ -34,18 +34,18 @@ class StdDelegates {
             Fiber.sleep(1)
             true
         }
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ipLazySync
         }).start().get())
     }
 
-    private @get:Suspendable val ipLazySync by quasarLazy @Suspendable {
+    @get:Suspendable private val ipLazySync by quasarLazy @Suspendable {
         Fiber.sleep(1)
         true
     }
 
     @Test fun testValLazySyncDelegProp() {
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ipLazySync
         }).start().get())
     }
@@ -55,18 +55,18 @@ class StdDelegates {
             Fiber.sleep(1)
             true
         }
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ipLazyPub
         }).start().get())
     }
 
-    private @get:Suspendable val ipLazyPub by lazy(LazyThreadSafetyMode.PUBLICATION) @Suspendable {
+    @get:Suspendable private val ipLazyPub by lazy(LazyThreadSafetyMode.PUBLICATION) @Suspendable {
         Fiber.sleep(1)
         true
     }
 
     @Test fun testValLazyPubDelegProp() {
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ipLazyPub
         }).start().get())
     }
@@ -76,18 +76,18 @@ class StdDelegates {
             Fiber.sleep(1)
             true
         }
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ipLazyNone
         }).start().get())
     }
 
-    private @get:Suspendable val ipLazyNone by lazy(LazyThreadSafetyMode.NONE) @Suspendable {
+    @get:Suspendable private val ipLazyNone by lazy(LazyThreadSafetyMode.NONE) @Suspendable {
         Fiber.sleep(1)
         true
     }
 
     @Test fun testValLazyUnsafeDelegProp() {
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ipLazyNone
         }).start().get())
     }
@@ -98,7 +98,7 @@ class StdDelegates {
             Fiber.sleep(1)
             println("$old -> $new")
         }
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ivObs
         }).start().get())
     }
@@ -110,7 +110,7 @@ class StdDelegates {
     }
 
     @Test fun testValObservableDelegProp() {
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             ivObs
         }).start().get())
     }
@@ -133,7 +133,7 @@ class StdDelegates {
             Fiber.sleep(1)
             println("$old -> $new")
         }
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             mvObs = true
             mvObs
         }).start().get())
@@ -152,7 +152,7 @@ class StdDelegates {
     }
 
     @Test fun testVarObservableSetDelegProp() {
-        Assert.assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
+        assertTrue(Fiber(scheduler, SuspendableCallable<Boolean> @Suspendable {
             mvObs = true
             mvObs
         }).start().get())


### PR DESCRIPTION
- Remove unused `static final` field from `ExternalizableKryoSerializer`.
- Fix some spelling errors and compiler warnings.
- Remove some more Gradle cruft.
- Tidy up more imports.