### PR TITLE
CORE-1519: Optimise common super class calculation when one class is java.lang.Object.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
@@ -59,8 +59,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.TreeMap;
 import java.util.Objects;
+import java.util.TreeMap;
 
 /**
  * <p>
@@ -71,8 +71,10 @@ import java.util.Objects;
  * @author Matthias Mann
  * @author pron
  */
-public class MethodDatabase {
+public final class MethodDatabase {
+    private static final String JAVA_OBJECT = "java/lang/Object";
     private static final int ASMAPI = Opcodes.ASM5;
+
     private final WeakReference<ClassLoader> clRef;
     private final SuspendableClassifier classifier;
     private final NavigableMap<String, ClassEntry> classes;
@@ -274,6 +276,9 @@ public class MethodDatabase {
     }
 
     String getCommonSuperClass(String classA, String classB) {
+        if (JAVA_OBJECT.equals(classA) || JAVA_OBJECT.equals(classB)) {
+            return JAVA_OBJECT;
+        }
         List<String> listA = getSuperClasses(classA);
         List<String> listB = getSuperClasses(classB);
         if (listA == null || listB == null) {
@@ -299,7 +304,7 @@ public class MethodDatabase {
             if ("java/lang/Throwable".equals(className))
                 return true;
 
-            if ("java/lang/Object".equals(className))
+            if (JAVA_OBJECT.equals(className))
                 return false;
 
             String superClass = getDirectSuperClass(className);
@@ -395,7 +400,7 @@ public class MethodDatabase {
         List<String> result = new ArrayList<>();
         for (;;) {
             result.add(0, className);
-            if ("java/lang/Object".equals(className)) {
+            if (JAVA_OBJECT.equals(className)) {
                 return result;
             }
 


### PR DESCRIPTION
Quasar's "common super class" algorithm assumes that the byte code for a class's super classes is always readable via that class's own classloader. This is not necessarily true when that class belongs to an OSGi bundle within an OSGi framework, which requires that the classloader have a "bundle wiring" to the super class's package as well.

Quasar currently knows nothing about OSGi or bundle wirings, which means that its common super class algorithm can fail within an OSGi framework. However, we can reduce the likelihood of it failing by observing up front that the common super class of `java.lang.Object` and _anything_ **must** be `java.lang.Object`.