### PR TITLE
CORE-1790: Use an inline function to make MethodOverloadTest more robust

### DIFF
--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/MethodOverloadTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/MethodOverloadTest.kt
@@ -23,9 +23,13 @@ import org.junit.Test
 
 class MethodOverloadTest {
 
+    // This inline method helps reproduce the issue. Kotlin adds bytecode with a source line > the end of the source
+    // file
+    inline fun reproduceTheIssueUsingInlineMethod() = arrayOf(0)
+
     @Suspendable
     fun function() {
-        function(arrayOf(0))
+        function(reproduceTheIssueUsingInlineMethod())
     }
 
     @Suspendable


### PR DESCRIPTION
This makes the unit test work on both Java 8 and 11.