### PR TITLE
CORE-1790: Port method overload fix to 0.8

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTrace.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTrace.java
@@ -114,15 +114,27 @@ public class ExtendedStackTrace implements Iterable<ExtendedStackTraceElement> {
 
         @Override
         public Member run() throws IOException {
+            final AtomicReference<String> exactMatch = new AtomicReference<>();
             final AtomicReference<String> descriptor = new AtomicReference<>();
-            findMethod(este.getDeclaringClass(), este.getMethodName(), este.getLineNumber(), descriptor);
+            findMethod(este.getDeclaringClass(), este.getMethodName(), este.getLineNumber(), exactMatch, descriptor);
 
-            if (descriptor.get() != null) {
-                final String desc = descriptor.get();
-                for (Member m : methods) {
-                    if (este.getMethodName().equals(getName(m)) && desc.equals(getDescriptor(m))) {
-                        return m;
-                    }
+            String exactMatchValue = exactMatch.get();
+            String descriptorValue = descriptor.get();
+
+            if (exactMatchValue != null) {
+                return getMatchingMethod(exactMatchValue);
+            }
+            else if (descriptorValue != null) {
+                return getMatchingMethod(descriptorValue);
+            } else {
+                return null;
+            }
+        }
+
+        private Member getMatchingMethod(String targetDescriptor) {
+            for (Member m : methods) {
+                if (este.getMethodName().equals(getName(m)) && targetDescriptor.equals(getDescriptor(m))) {
+                    return m;
                 }
             }
             return null;

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/MethodOverloadTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/MethodOverloadTest.kt
@@ -23,9 +23,14 @@ import org.junit.Test
 
 class MethodOverloadTest {
 
+    // This inline method helps reproduce the issue. Kotlin adds bytecode with a source line > the end of the source
+    // file
+    @Suspendable
+    inline fun reproduceTheIssueUsingInlineMethod() = arrayOf(0)
+
     @Suspendable
     fun function() {
-        function(arrayOf(0))
+        function(reproduceTheIssueUsingInlineMethod())
     }
 
     @Suspendable

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/MethodOverloadTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/MethodOverloadTest.kt
@@ -25,7 +25,6 @@ class MethodOverloadTest {
 
     // This inline method helps reproduce the issue. Kotlin adds bytecode with a source line > the end of the source
     // file
-    @Suspendable
     inline fun reproduceTheIssueUsingInlineMethod() = arrayOf(0)
 
     @Suspendable


### PR DESCRIPTION
- Use an inline function to make MethodOverloadTest more robust
- Port fix to 0.8 branch

See https://github.com/corda/quasar/pull/9 for the 0.7 fix.