### PR TITLE
CORE-3417: Ensure Java agent can unload unused ClassLoaders.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/DefaultSuspendableClassifier.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/DefaultSuspendableClassifier.java
@@ -14,21 +14,24 @@
 package co.paralleluniverse.fibers.instrument;
 
 import co.paralleluniverse.fibers.instrument.MethodDatabase.SuspendableType;
+import java.util.List;
 import java.util.ServiceLoader;
+import java.util.stream.StreamSupport;
 
 import static co.paralleluniverse.fibers.instrument.Classes.LAMBDA_METHOD_PREFIX;
 import static co.paralleluniverse.fibers.instrument.Classes.SUSPEND_EXECUTION_NAME;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 /**
  *
  * @author pron
  */
 public class DefaultSuspendableClassifier implements SuspendableClassifier {
-    private final ServiceLoader<SuspendableClassifier> loader;
+    private final List<SuspendableClassifier> classifiers;
     private final SuspendableClassifier simpleClassifier;
 
     public DefaultSuspendableClassifier(ClassLoader classLoader) {
-        this.loader = ServiceLoader.load(SuspendableClassifier.class, classLoader);
+        this.classifiers = StreamSupport.stream(ServiceLoader.load(SuspendableClassifier.class, classLoader).spliterator(), false).collect(toUnmodifiableList());
         this.simpleClassifier = new SimpleSuspendableClassifier(classLoader);
     }
 
@@ -39,7 +42,7 @@ public class DefaultSuspendableClassifier implements SuspendableClassifier {
 
         try {
             // classifier service
-            for (SuspendableClassifier sc : loader) {
+            for (SuspendableClassifier sc : classifiers) {
                 st = sc.isSuspendable(db, sourceName, sourceDebugInfo, isInterface, className, superClassName, interfaces, methodName, methodDesc, methodSignature, methodExceptions);
                 if (st != null)
                     return st;

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
@@ -83,12 +83,8 @@ import co.paralleluniverse.common.resource.ClassLoaderUtil;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.lang.instrument.Instrumentation;
-import java.lang.ref.WeakReference;
 import java.security.ProtectionDomain;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static co.paralleluniverse.common.asm.ASMUtil.ASMAPI;
 
@@ -100,7 +96,6 @@ import static co.paralleluniverse.common.asm.ASMUtil.ASMAPI;
 public class JavaAgent {
     private static final String USAGE = "Usage: vdmcbx(exclusion;...)l(exclusion;...) (verbose, debug, allow monitors, check class, allow blocking)";
     private static volatile boolean ACTIVE;
-    private static final Set<WeakReference<ClassLoader>> classLoaders = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     public static void premain(String agentArguments, Instrumentation instrumentation) {
         if (!instrumentation.isRetransformClassesSupported())
@@ -130,7 +125,7 @@ public class JavaAgent {
                     case 'a': {
                             final String s = parseArgBrackets(agentArguments, ++i);
                             i += s.length() + 1;
-                            final String[] attr = s.split("\\=");
+                            final String[] attr = s.split("=");
                             if (attr.length > 1) {
                                 final String[] names = attr[1].split(",");
                                 instrumentor.addTypeDesc(attr[0], toTypeDescriptors(names));
@@ -196,7 +191,6 @@ public class JavaAgent {
 
         Retransform.instrumentation = instrumentation;
         Retransform.instrumentor = instrumentor;
-        Retransform.classLoaders = classLoaders;
 
         instrumentation.addTransformer(new Transformer(instrumentor), true);
     }
@@ -240,9 +234,6 @@ public class JavaAgent {
                 return null;
 
             Retransform.beforeTransform(className, classBeingRedefined, classfileBuffer);
-
-            if (loader != null)
-                classLoaders.add(new WeakReference<>(loader));
 
             try {
                 final byte[] transformed = instrumentor.instrumentClass(loader, className, classfileBuffer);

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Retransform.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Retransform.java
@@ -21,11 +21,7 @@ import java.io.PrintWriter;
 import java.lang.instrument.ClassDefinition;
 import java.lang.instrument.Instrumentation;
 import java.lang.instrument.UnmodifiableClassException;
-import java.lang.ref.WeakReference;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -35,8 +31,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class Retransform {
     static volatile Instrumentation instrumentation;
     static volatile QuasarInstrumentor instrumentor;
-    static volatile Set<WeakReference<ClassLoader>> classLoaders = Collections.newSetFromMap(new ConcurrentHashMap<>());
-    
+
     private static final CopyOnWriteArrayList<ClassLoadListener> listeners = new CopyOnWriteArrayList<>();
 
     public static void retransform(Class<?> clazz) throws UnmodifiableClassException {
@@ -59,22 +54,6 @@ public class Retransform {
         return instrumentor;
     }
 
-//    public static boolean isInstrumented(String className) {
-//        for (Iterator<WeakReference<ClassLoader>> it = classLoaders.iterator(); it.hasNext();) {
-//            final WeakReference<ClassLoader> ref = it.next();
-//            final ClassLoader loader = ref.get();
-//            if (loader == null)
-//                it.remove();
-//            else {
-//                try {
-//                    if (isInstrumented(Class.forName(className, false, loader)))
-//                        return true;
-//                } catch (ClassNotFoundException ex) {
-//                }
-//            }
-//        }
-//        return false;
-//    }
     public static void addWaiver(String className, String methodName) {
         SuspendableHelper.addWaiver(className, methodName);
     }

--- a/quasar-osgi-tests/tests.bndrun
+++ b/quasar-osgi-tests/tests.bndrun
@@ -36,7 +36,7 @@ java: ${project.javaExecutable}
     begin=-1
 -runbundles: \
 	assertj-core;version='[3.16.1,3.16.2)',\
-	co.paralleluniverse.quasar-core;version='[0.8.6,0.8.7)',\
+	co.paralleluniverse.quasar-core;version='[0.8.8,0.8.9)',\
 	com.esotericsoftware.kryo;version='[4.0.2,4.0.3)',\
 	com.esotericsoftware.minlog;version='[1.3.0,1.3.1)',\
 	com.google.guava;version='[30.1.1,30.1.2)',\
@@ -51,8 +51,8 @@ java: ${project.javaExecutable}
 	junit-platform-launcher;version='[1.8.2,1.8.3)',\
 	org.objenesis;version='[2.5.1,2.5.2)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	osgi-base;version='[0.8.6,0.8.7)',\
-	osgi-exception;version='[0.8.6,0.8.7)',\
-	quasar-osgi-tests;version='[0.8.6,0.8.7)',\
+	osgi-base;version='[0.8.8,0.8.9)',\
+	osgi-exception;version='[0.8.8,0.8.9)',\
+	quasar-osgi-tests;version='[0.8.8,0.8.9)',\
 	slf4j.api;version='[1.7.30,1.7.31)',\
 	slf4j.simple;version='[1.7.30,1.7.31)'


### PR DESCRIPTION
Remove strong `ClassLoader` references from `DefaultSuspendableClassifier`. This allows the instrumentor's
```java
WeakHashMap<ClassLoader, MethodDatabase>
```
instance to release unused classloaders as it is supposed to.

Also remove `Set<WeakReference<ClassLoader>>` _completely_ from `JavaAgent` as it does _not_ behave as a weak `Set<ClassLoader`, and is also unused anyway.