### PR TITLE
CORE-4077: Execute OSGi ExtractSuperClasses via a lambda.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -419,6 +419,7 @@ project (':quasar-core') {
     }
 
     configurations {
+        agentCompileOnly.extendsFrom provided
         bundleImplementation.extendsFrom implementation
         bundleImplementation.extendsFrom agentImplementation
     }
@@ -454,6 +455,7 @@ project (':quasar-core') {
     compileAgentJava {
         options.compilerArgs += [
             '--patch-module', "${project.moduleName}.agent=${sourceSets.main.output.asPath}",
+            '--module-path', configurations.agentCompileClasspath.asPath,
             '--module-version', project.version
         ]
     }

--- a/quasar-core/src/main/agent/module-info.java
+++ b/quasar-core/src/main/agent/module-info.java
@@ -1,5 +1,6 @@
 module co.paralleluniverse.quasar.core.agent {
     requires java.instrument;
+    requires static org.objectweb.asm;
 
     exports co.paralleluniverse.common.asm;
     exports co.paralleluniverse.common.resource;

--- a/quasar-core/src/main/agent/module-info.java
+++ b/quasar-core/src/main/agent/module-info.java
@@ -8,4 +8,3 @@ module co.paralleluniverse.quasar.core.agent {
 
     opens co.paralleluniverse.fibers.suspend to co.paralleluniverse.quasar.core.osgi;
 }
-

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
@@ -94,7 +94,7 @@ import static co.paralleluniverse.common.asm.ASMUtil.ASMAPI;
  * @author Matthias Mann
  */
 public class JavaAgent {
-    private static final String USAGE = "Usage: vdmcbx(exclusion;...)l(exclusion;...) (verbose, debug, allow monitors, check class, allow blocking)";
+    private static final String USAGE = "Usage: vdmcb0x(exclusion;...)l(exclusion;...) (verbose, debug, allow monitors, check class, allow blocking, disable OSGi support)";
     private static volatile boolean ACTIVE;
 
     public static void premain(String agentArguments, Instrumentation instrumentation) {
@@ -173,6 +173,9 @@ public class JavaAgent {
                                 instrumentor.addExcludedClassLoader(x);
                             }
                         }
+                        break;
+                    case '0':
+                        OSGiClassLoader.disable();
                         break;
                     default:
                         throw new IllegalStateException(USAGE);

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
@@ -42,6 +42,7 @@
 package co.paralleluniverse.fibers.instrument;
 
 import co.paralleluniverse.common.resource.ClassLoaderUtil;
+import co.paralleluniverse.fibers.instrument.function.BiFunction;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
 import java.io.File;
@@ -50,10 +51,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Constructor;
 import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -457,15 +455,11 @@ public final class MethodDatabase {
     }
 
     private Map<String, String> getOSGiSuperClassesFor(String className, ClassLoader cl) {
-        Constructor<PrivilegedExceptionAction<Map<String, String>>> osgiSuperClassExtractor = OSGiClassLoader.fetchSuperClassExtractorConstructor(cl);
+        BiFunction<String, ClassLoader, Map<String, String>> fetchSuperClassExtractor = OSGiClassLoader.fetchSuperClassExtractor(cl);
         try {
-            return (osgiSuperClassExtractor != null) ? doPrivileged(osgiSuperClassExtractor.newInstance(className, cl)) : null;
-        } catch (PrivilegedActionException e) {
-            Exception ex = e.getException();
-            error(ex.getMessage(), ex);
-            return null;
-        } catch (ReflectiveOperationException ex) {
-            error(ex.getMessage(), ex);
+            return (fetchSuperClassExtractor == null) ? null : fetchSuperClassExtractor.applyThrowing(className, cl);
+        } catch (Exception e) {
+            error(e.getMessage(), e);
             return null;
         }
     }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/OSGiClassLoader.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/OSGiClassLoader.java
@@ -1,11 +1,11 @@
 package co.paralleluniverse.fibers.instrument;
 
+import co.paralleluniverse.fibers.instrument.function.BiFunction;
+
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.security.PrivilegedAction;
-import java.security.PrivilegedExceptionAction;
 import java.util.Map;
 
 import static co.paralleluniverse.common.resource.ClassLoaderUtil.classToResource;
@@ -18,9 +18,10 @@ import static java.security.AccessController.doPrivileged;
  */
 final class OSGiClassLoader extends ClassLoader {
     private static final String SUPER_CLASS_EXTRACTOR_CLASS_NAME = "co.paralleluniverse.fibers.osgi.ExtractSuperClasses";
+    private static final String GET_EXTRACTOR_METHOD_NAME = "getExtractorMethod";
     private static final String BUNDLE_CLASS_NAME = "org.osgi.framework.Bundle";
 
-    private static Constructor<PrivilegedExceptionAction<Map<String, String>>> superClassExtractorConstructor;
+    private static BiFunction<String, ClassLoader, Map<String, String>> superClassExtractor;
     private static ClassLoader osgiLoader;
 
     static {
@@ -66,27 +67,34 @@ final class OSGiClassLoader extends ClassLoader {
     }
 
     @SuppressWarnings("unchecked")
-    private static Constructor<PrivilegedExceptionAction<Map<String, String>>> createSuperClassExtractorConstructor(ClassLoader cl) {
+    private static BiFunction<String, ClassLoader, Map<String, String>> createSuperClassExtractor(ClassLoader cl) {
         final ClassLoader loader = getOSGiLoaderFrom(cl);
         if (loader == null) {
             return null;
         }
 
         try {
-            return ((Class<PrivilegedExceptionAction<Map<String, String>>>) Class.forName(SUPER_CLASS_EXTRACTOR_CLASS_NAME, false, loader))
-                .getDeclaredConstructor(String.class, ClassLoader.class);
+            Class<?> extractorClass = Class.forName(SUPER_CLASS_EXTRACTOR_CLASS_NAME, false, loader);
+            return (BiFunction<String, ClassLoader, Map<String, String>>) extractorClass.getMethod(GET_EXTRACTOR_METHOD_NAME).invoke(null);
         } catch (ReflectiveOperationException e) {
-            throw new InternalError("Constructor for " + SUPER_CLASS_EXTRACTOR_CLASS_NAME + " not found", e);
+            throw new InternalError("Failed to initialise " + SUPER_CLASS_EXTRACTOR_CLASS_NAME, e);
         }
     }
 
-    static synchronized Constructor<PrivilegedExceptionAction<Map<String, String>>> fetchSuperClassExtractorConstructor(ClassLoader cl) {
-        if (superClassExtractorConstructor == null) {
-            superClassExtractorConstructor = doPrivileged(
-                (PrivilegedAction<Constructor<PrivilegedExceptionAction<Map<String, String>>>>) () ->
-                    createSuperClassExtractorConstructor(cl)
+    static synchronized void disable() {
+        if (osgiLoader == null) {
+            // Only disable OSGi support if it hasn't been activated yet.
+            superClassExtractor = (a, b) -> null;
+        }
+    }
+
+    static synchronized BiFunction<String, ClassLoader, Map<String, String>> fetchSuperClassExtractor(ClassLoader cl) {
+        if (superClassExtractor == null) {
+            superClassExtractor = doPrivileged(
+                (PrivilegedAction<BiFunction<String, ClassLoader, Map<String, String>>>) () ->
+                    createSuperClassExtractor(cl)
             );
         }
-        return superClassExtractorConstructor;
+        return superClassExtractor;
     }
 }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/function/BiFunction.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/function/BiFunction.java
@@ -1,0 +1,19 @@
+package co.paralleluniverse.fibers.instrument.function;
+
+/**
+ * Extends {@link java.util.function.BiFunction} to support checked exceptions.
+ */
+@FunctionalInterface
+public interface BiFunction<T, U, R> extends java.util.function.BiFunction<T, U, R> {
+    R applyThrowing(T a, U b) throws Exception;
+
+    default R apply(T a, U b) {
+        try {
+            return applyThrowing(a, b);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+}

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/osgi/ExtractSuperClasses.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/osgi/ExtractSuperClasses.java
@@ -2,6 +2,7 @@ package co.paralleluniverse.fibers.osgi;
 
 import co.paralleluniverse.common.resource.ClassLoaderUtil;
 import co.paralleluniverse.fibers.instrument.ExtractSuperClass;
+import co.paralleluniverse.fibers.instrument.function.BiFunction;
 import org.osgi.framework.BundleReference;
 import org.osgi.framework.wiring.BundleCapability;
 import org.osgi.framework.wiring.BundleWire;
@@ -10,10 +11,13 @@ import org.osgi.framework.wiring.BundleWiring;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  * This class is not used directly because {@link ClassLoader#getSystemClassLoader()}
@@ -22,35 +26,32 @@ import java.util.Map;
  * framework does exist inside.
  */
 @SuppressWarnings("unused")
-public final class ExtractSuperClasses implements PrivilegedExceptionAction<Map<String, String>> {
+public final class ExtractSuperClasses {
     private static final String PACKAGE_WIRING = "osgi.wiring.package";
     private static final String JAVA_OBJECT = "java/lang/Object";
 
-    private final String className;
-    private final ClassLoader cl;
-
-    public ExtractSuperClasses(String className, ClassLoader cl) {
-        this.className = className;
-        this.cl = cl;
+    public static BiFunction<String, ClassLoader, Map<String, String>> getExtractorMethod() {
+        return ExtractSuperClasses::extractSuperClasses;
     }
 
-    @Override
-    public Map<String, String> run() throws Exception {
-        final Extractor extractor;
+    public static Map<String, String> extractSuperClasses(String className, ClassLoader cl) throws Exception {
         try {
-            extractor = new Extractor(cl);
-        } catch (RuntimeException e) {
-            // This classloader has no underlying OSGi bundle.
-            return null;
+            return (cl instanceof BundleReference) ? doPrivileged((PrivilegedExceptionAction<Map<String, String>>) () ->
+               new Extractor((BundleReference) cl).extractFor(className)
+            ) : null;
+        } catch (PrivilegedActionException e) {
+            throw e.getException();
         }
-        return extractor.extractFor(className);
+    }
+
+    private ExtractSuperClasses() {
     }
 
     private static final class Extractor {
         private final BundleWiring initialWiring;
 
-        Extractor(ClassLoader cl) {
-            initialWiring = ((BundleReference) cl).getBundle().adapt(BundleWiring.class);
+        Extractor(BundleReference bundleReference) {
+            initialWiring = bundleReference.getBundle().adapt(BundleWiring.class);
         }
 
         Map<String, String> extractFor(String className) throws Exception {


### PR DESCRIPTION
Create and execute the `ExtractSuperClasses` object via a lambda rather than using Java reflection. This removes Java reflection from normal operation entirely.

Also fix incremental build of OSGi Quasar's agent.