### PR TITLE
CORE-4674: Instrument Kotlin 1.6.x lambdas correctly.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 quasarVersion=0.8.8_r3-SNAPSHOT
-kotlinVersion=1.4.32
+kotlinVersion=1.6.21
 taskTreeVersion=1.3.1
 shadowVersion=6.1.0
 artifactoryVersion=4.21.0

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
@@ -56,7 +56,8 @@ final class Classes {
     static final String SUSPEND_EXECUTION_NAME         = "co/paralleluniverse/fibers/suspend/SuspendExecution";
     static final String STACK_OPS_NAME                 = "co/paralleluniverse/fibers/suspend/StackOps";
 
-    static final String LAMBDA_METHOD_PREFIX            = "lambda$";
+    static final String LAMBDA_METHOD_PREFIX           = "lambda$";
+    static final String KOTLIN_LAMBDA_SUFFIX           = "$lambda-";
 
     static final String DONT_INSTRUMENT_DESC = Type.getDescriptor(DontInstrument.class);
     static final String INSTRUMENTED_DESC    = Type.getDescriptor(Instrumented.class);

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/DefaultSuspendableClassifier.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/DefaultSuspendableClassifier.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.ServiceLoader;
 import java.util.stream.StreamSupport;
 
+import static co.paralleluniverse.fibers.instrument.Classes.KOTLIN_LAMBDA_SUFFIX;
 import static co.paralleluniverse.fibers.instrument.Classes.LAMBDA_METHOD_PREFIX;
 import static co.paralleluniverse.fibers.instrument.Classes.SUSPEND_EXECUTION_NAME;
 import static java.util.stream.Collectors.toUnmodifiableList;
@@ -57,9 +58,10 @@ public class DefaultSuspendableClassifier implements SuspendableClassifier {
             if (checkExceptions(methodExceptions))
                 return SuspendableType.SUSPENDABLE;
 
-            // lambda$
-            if (methodName.startsWith(LAMBDA_METHOD_PREFIX))
+            // lambda$ or $lambda-x
+            if (methodName.startsWith(LAMBDA_METHOD_PREFIX) || methodName.contains(KOTLIN_LAMBDA_SUFFIX)) {
                 return SuspendableType.SUSPENDABLE;
+            }
         } catch (Exception e) {
             e.printStackTrace();
             throw e;

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/InstrumentClass.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/InstrumentClass.java
@@ -228,8 +228,9 @@ class InstrumentClass extends ClassVisitor {
                     }
                 }
             };
+        } else {
+            return super.visitMethod(access, name, desc, signature, exceptions);
         }
-        return super.visitMethod(access, name, desc, signature, exceptions);
     }
 
     @Override

--- a/quasar-kotlin/build.gradle
+++ b/quasar-kotlin/build.gradle
@@ -58,11 +58,13 @@ tasks.named('check') {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
         jvmTarget = '11'
-        apiVersion = '1.4'
-        languageVersion = '1.4'
-        // We should enable this, but are currently blocked by a Kotlin bug!
+        apiVersion = '1.6'
+        languageVersion = '1.6'
+        allWarningsAsErrors = true
+        // We need to enable this, but must watch for compiler warnings about
+        // abstract methods in the base class not having an implementation!
         // See https://youtrack.jetbrains.com/issue/KT-46253
-        //freeCompilerArgs = ['-Xjvm-default=all']
+        freeCompilerArgs = [ '-Xjvm-default=all' ]
     }
 }
 

--- a/quasar-kotlin/src/main/java/co/paralleluniverse/kotlin/KotlinClassifier.java
+++ b/quasar-kotlin/src/main/java/co/paralleluniverse/kotlin/KotlinClassifier.java
@@ -89,35 +89,40 @@ public class KotlinClassifier implements SuspendableClassifier {
         boolean isInterface, String className, String superClassName, String[] interfaces,
         String methodName, String methodDesc, String methodSignature, String[] methodExceptions
     ) {
-        if (className == null)
+        if (className == null || methodName == null) {
             return null;
+        }
 
         for (final String[] s : supers) {
-            if (className.equals(s[0]))
+            if (className.equals(s[0])) {
                 for (int i = 1; i < s.length; i++) {
-                    if (methodName != null && methodName.matches(s[i])) {
-                        if (db.isVerbose())
+                    if (methodName.matches(s[i])) {
+                        if (db.isVerbose()) {
                             db.getLog().log(LogLevel.INFO, KotlinClassifier.class.getName() + ": " + className + "." + methodName + " supersOrEqual " + s[0] + "." + s[i]);
+                        }
                         return MethodDatabase.SuspendableType.SUSPENDABLE_SUPER;
                     }
                 }
+            }
         }
 
         // Don't consider Kotlin user files without inner classes
         if (!className.startsWith(PKG_PREFIX)
-            && !(className.contains("$") && sourceName != null && sourceName.toLowerCase().endsWith(".kt")))
+            && !(className.contains("$") && sourceName != null && sourceName.toLowerCase().endsWith(".kt"))) {
             return null;
+        }
 
         // Exclude packages known not to suspend
         for (final String s : excludePrefixes) {
-            if (className.startsWith(s))
+            if (className.startsWith(s)) {
                 return null;
+            }
         }
 
         for (final String[] s : supers) {
             if (SimpleSuspendableClassifier.extendsOrImplements(s[0], db, className, superClassName, interfaces))
                 for (int i = 1; i < s.length; i++) {
-                    if (methodName != null && methodName.matches(s[i])) {
+                    if (methodName.matches(s[i])) {
                         if (db.isVerbose())
                             db.getLog().log(LogLevel.INFO, KotlinClassifier.class.getName() + ": " + className + "." + methodName + " extends " + s[0] + "." + s[i]);
                         return MethodDatabase.SuspendableType.SUSPENDABLE;
@@ -126,8 +131,9 @@ public class KotlinClassifier implements SuspendableClassifier {
         }
 
         // Java7 compilation scheme
-        if (methodName != null && methodName.contains("access$"))
+        if (methodName.startsWith("access$") || methodName.contains("$lambda-")) {
             return MethodDatabase.SuspendableType.SUSPENDABLE;
+        }
 
         return null;
     }

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/MethodOverloadTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/MethodOverloadTest.kt
@@ -21,10 +21,12 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assume.assumeTrue
 import org.junit.Test
 
+@Suppress("unused")
 class MethodOverloadTest {
 
     // This inline method helps reproduce the issue. Kotlin adds bytecode with a source line > the end of the source
     // file
+    @Suppress("NOTHING_TO_INLINE")
     inline fun reproduceTheIssueUsingInlineMethod() = arrayOf(0)
 
     @Suspendable
@@ -32,6 +34,7 @@ class MethodOverloadTest {
         function(reproduceTheIssueUsingInlineMethod())
     }
 
+    @Suppress("unused_parameter")
     @Suspendable
     fun function(m: Any) {
         Fiber.yield()

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/OOTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/OOTest.kt
@@ -33,10 +33,10 @@ class OOTest {
         @Suspendable inline fun fiberSleepInline() { Fiber.sleep(1) }
     }
 
-    val scheduler = FiberForkJoinScheduler("test", 4, null, false)
+    private val scheduler = FiberForkJoinScheduler("test", 4, null, false)
 
     class D {
-        var v = true
+        private var v = true
 
         @Suspendable operator fun getValue(thisRef: Any?, prop: KProperty<*>): Boolean {
             fiberSleepInline()
@@ -97,7 +97,7 @@ class OOTest {
         }).start().get())
     }
 
-    val iv = true
+    private val iv = true
     @Suspendable get() {
         fiberSleepInline()
         return field
@@ -115,7 +115,7 @@ class OOTest {
         }).start().get())
     }
 
-    var mv = true
+    private var mv = true
         @Suspendable get() {
             fiberSleepInline()
             return field
@@ -151,7 +151,7 @@ class OOTest {
         }).start().get())
     }
 
-    var md by D()
+    private var md by D()
         @Suspendable get
         @Suspendable set
 
@@ -181,7 +181,7 @@ class OOTest {
         }).start().get())
     }
 
-    val ivInline: Boolean @Suspendable inline get() {
+    private val ivInline: Boolean @Suspendable inline get() {
         fiberSleepInline()
         return true
     }
@@ -198,7 +198,7 @@ class OOTest {
         }).start().get())
     }
 
-    var mvInline : Boolean
+    private var mvInline : Boolean
         @Suspendable inline get() {
             fiberSleepInline()
             return true
@@ -248,7 +248,7 @@ class OOTest {
         }
     }
 
-    var mdInline by DInline()
+    private var mdInline by DInline()
         @Suspendable get
         @Suspendable set
 
@@ -278,7 +278,7 @@ class OOTest {
         }).start().get())
     }
 
-    enum class E(val data: Int?) {
+    enum class E(private val data: Int?) {
         V1(0),
         V2(1) {
             @Suspendable override fun enumFun() {
@@ -426,7 +426,7 @@ class OOTest {
         return true
     }
 
-    open class Base (val data: Int = 0) {
+    open class Base (private val data: Int = 0) {
         // NOT SUPPORTED: Kotlin's initializers are named <init> and we don't instrument those. Not an issue
         // because they're called by constructors which we don't instrument either (because it is most probably
         // impossible to unpark them).
@@ -446,6 +446,7 @@ class OOTest {
 
     }
 
+    @JvmDefaultWithCompatibility
     interface BaseTrait1 {
         @Suspendable fun doSleep() : Boolean {
             fiberSleepInline()
@@ -537,7 +538,12 @@ class OOTest {
         }).start().get())
     }
 
-    object O : DerivedDerived2()
+    object O : DerivedDerived2() {
+        override fun doSleep(): Boolean {
+            fiberSleepInline()
+            return true
+        }
+    }
 
     @Test fun testOOSimple() {
         assertTrue(Fiber(scheduler, SuspendableCallable @Suspendable {
@@ -581,7 +587,12 @@ class OOTest {
 
     @Test fun testOODerived2() {
         assertTrue(Fiber(scheduler, SuspendableCallable @Suspendable {
-            (object : DerivedDerived2() {}).doSleep()
+            (object : DerivedDerived2() {
+                override fun doSleep(): Boolean {
+                    fiberSleepInline()
+                    return true
+                }
+            }).doSleep()
             true
         }).start().get())
     }

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/_1_4_x/CallableReference.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/lang/_1_4_x/CallableReference.kt
@@ -22,15 +22,19 @@ class CallableReference {
     @Suspendable
     private fun apply(f: () -> String): String = f()
 
+    @Suppress("unused_parameter")
     @Suspendable
     private fun doNothing(f: () -> Unit) {doYield()}
 
+    @Suppress("unused_parameter")
     @Suspendable
     private fun doNothing1(f: (Int, String) -> Unit) {doYield()}
 
+    @Suppress("unused_parameter")
     @Suspendable
     private fun doNothing2(f: (Int, String, String) -> Unit) {doYield()}
 
+    @Suppress("unused_parameter")
     @Suspendable
     private fun doNothingVararg(x: Int, vararg y: String) {doYield()}
 


### PR DESCRIPTION
Kotlin 1.5+ began implementing lambdas using Java's bootstrap methods, and Kotlin 1.6.20 has ensured that lambdas are once again serializable by default. We can now consider using Quasar with Kotlin 1.6.20+.

Kotlin is also now generating a compiler warning for [KT-46253](https://youtrack.jetbrains.com/issue/KT-46253), so we can avoid this bug too by enabling
```
allWarningsAsErrors = true
```