### PR TITLE
ENT-6766: Fix ArrayOutOfBoundsException in Stack.popMethod.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Stack.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Stack.java
@@ -134,8 +134,9 @@ public final class Stack implements Serializable {
 
         int nextMethodIdx = sp + numSlots;
         int nextMethodSP = nextMethodIdx + FRAME_RECORD_SIZE;
-        if (nextMethodSP > dataObject.length)
+        if (nextMethodSP >= dataObject.length) {
             growStack(nextMethodSP);
+        }
 
         // clear next method's frame record
         dataLong[nextMethodIdx] = 0L;


### PR DESCRIPTION
Apply existing fix from [Quasar#309](https://github.com/puniverse/quasar/issues/309).