### PR TITLE
ENT-6766: Fix ArrayOutOfBoundsException for Stack.popMethod.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Stack.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Stack.java
@@ -165,8 +165,9 @@ public final class Stack extends StackOps implements Serializable {
 
         int nextMethodIdx = sp + numSlots;
         int nextMethodSP = nextMethodIdx + FRAME_RECORD_SIZE;
-        if (nextMethodSP > dataObject.length)
+        if (nextMethodSP >= dataObject.length) {
             growStack(nextMethodSP);
+        }
 
         // clear next method's frame record
         dataLong[nextMethodIdx] = 0L;


### PR DESCRIPTION
Apply existing fix from [#309](https://github.com/puniverse/quasar/issues/309).