### PR TITLE
CORE-4592: Fix NPE when OSGi framework not on classpath.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/OSGiClassLoader.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/OSGiClassLoader.java
@@ -24,6 +24,7 @@ final class OSGiClassLoader extends ClassLoader {
     private static final String BUNDLE_LOCATOR_CLASS_NAME = "co.paralleluniverse.fibers.osgi.BundleLocator";
     private static final String FIND_RESOURCE_OWNER_METHOD_NAME = "getFindResourceOwnerMethod";
     private static final String BUNDLE_CLASS_NAME = "org.osgi.framework.Bundle";
+    private static final BiPredicate<ClassLoader, Collection<Pattern>> FALSE = (a, b) -> false;
 
     private static BiPredicate<ClassLoader, Collection<Pattern>> bundleLocationExcluder;
     private static ResourceLocator findResourceOwner;
@@ -120,7 +121,7 @@ final class OSGiClassLoader extends ClassLoader {
                     createBundleLocationMatcher(cl)
             );
         }
-        return bundleLocationExcluder;
+        return bundleLocationExcluder != null ? bundleLocationExcluder : FALSE;
     }
 
     static synchronized ResourceLocator findResourceOwner(ClassLoader cl) {
@@ -129,13 +130,13 @@ final class OSGiClassLoader extends ClassLoader {
                 createFindResourceOwner(cl)
             );
         }
-        return findResourceOwner;
+        return findResourceOwner != null ? findResourceOwner : MethodDatabase::getBestClassLoaderFor;
     }
 
     static synchronized void disable() {
         if (osgiLoader == null) {
             // Only disable OSGi support if it hasn't been activated yet.
-            bundleLocationExcluder = (a, b) -> false;
+            bundleLocationExcluder = FALSE;
             findResourceOwner = MethodDatabase::getBestClassLoaderFor;
         }
     }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarInstrumentor.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarInstrumentor.java
@@ -326,7 +326,7 @@ public final class QuasarInstrumentor {
             return false;
         }
         final BiPredicate<ClassLoader, Collection<Pattern>> bundleMatcher = OSGiClassLoader.fetchBundleLocationMatcher(loader);
-        return bundleMatcher != null && bundleMatcher.test(loader, excludedBundleLocations);
+        return bundleMatcher.test(loader, excludedBundleLocations);
     }
 
     synchronized void addExcludedBundleLocation(String glob) {
@@ -338,7 +338,7 @@ public final class QuasarInstrumentor {
             return false;
         }
         final BiPredicate<ClassLoader, Collection<Pattern>> bundleMatcher = OSGiClassLoader.fetchBundleLocationMatcher(loader);
-        return bundleMatcher != null && bundleMatcher.test(loader, cachedBundleLocations);
+        return bundleMatcher.test(loader, cachedBundleLocations);
     }
 
     synchronized void addCachedBundleLocation(String glob) {


### PR DESCRIPTION
Fix `OSGIClassLoader` function references never to be `null`. This avoids a NPE whenever there is no OSGi framework on the classpath.