### PR TITLE
CORE-4818: Do not disable caching when reading URLConnection.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/common/resource/ClassLoaderUtil.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/resource/ClassLoaderUtil.java
@@ -33,12 +33,10 @@ package co.paralleluniverse.common.resource;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.net.URLConnection;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
@@ -192,16 +190,6 @@ public final class ClassLoaderUtil {
             } catch (IOException ignored) {
             }
         }
-    }
-
-    public static InputStream getResourceAsStream(ClassLoader cl, String resource) throws IOException {
-        final URL url = cl.getResource(resource);
-        if (url == null) {
-            return null;
-        }
-        final URLConnection uc = url.openConnection();
-        uc.setUseCaches(false);
-        return uc.getInputStream();
     }
 
     /**

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
@@ -50,7 +50,6 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.lang.ref.WeakReference;
 import java.net.URL;
-import java.net.URLConnection;
 import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.HashMap;
@@ -395,9 +394,7 @@ public final class MethodDatabase {
     private InputStream privilegedOpenInputStream(URL resource) {
         return doPrivileged((PrivilegedAction<InputStream>)() -> {
             try {
-                final URLConnection uc = resource.openConnection();
-                uc.setUseCaches(false);
-                return uc.getInputStream();
+                return resource.openStream();
             } catch(IOException e) {
                 final String message = "While opening " + resource;
                 error(message, e);

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SuspendablesScanner.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SuspendablesScanner.java
@@ -38,7 +38,6 @@ import java.io.PrintStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.net.URLConnection;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -226,9 +225,7 @@ public class SuspendablesScanner extends Task {
                 if (resource.startsWith("java/util") || resource.startsWith("java/lang") || resource.startsWith("co/paralleluniverse/asm"))
                     return;
                 if (isClassFile(url.getFile())) {
-                    URLConnection uc = url.openConnection();
-                    uc.setUseCaches(false);
-                    try (InputStream is = uc.getInputStream()) {
+                    try (InputStream is = url.openStream()) {
                         if (is == null)
                             throw new IOException("Resource " + resource + " not found (" + url + ")");
                         new ClassReader(is)
@@ -664,7 +661,7 @@ public class SuspendablesScanner extends Task {
 
     private ClassNode fill(ClassNode node) {
         if (node.supers == null) {
-            try (InputStream is = ClassLoaderUtil.getResourceAsStream(cl, classToResource(node.name))) {
+            try (InputStream is = cl.getResourceAsStream(classToResource(node.name))) {
                 final ClassReader cr = new ClassReader(is);
                 cr.accept(new ClassNodeVisitor(false, ASMAPI, null), ClassReader.SKIP_DEBUG | ClassReader.SKIP_CODE);
                 assert node.supers != null;


### PR DESCRIPTION
Disabling caching forces Java to create a new `JarFile` for each `JarURLConnection`. This causes a quadratic performance penalty when instrumenting signed jars because each `JarFile` must validate the jar's signatures.

Revert to previous behaviour of using `URLConnection.defaultUseCaches` setting. (We appear to have inherited the original change from the original 0.8 code.)