### PR TITLE
CORE-4839: Optimise the getBestClassLoader() algorithm.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,12 +117,12 @@ subprojects {
         provided "org.apache.ant:ant:1.9.9" // version 1.10 and upwards requires JDK 8
         implementation "com.google.guava:guava:20.0" // version 21.0 and upwards requires JDK 8
         timewarp 'co.paralleluniverse:timewarp:0.1.0-SNAPSHOT'
-        testImplementation 'junit:junit:4.12'
+        testImplementation 'junit:junit:4.13.2'
+        testImplementation "org.assertj:assertj-core:$assertjVersion"
         testImplementation('com.google.truth:truth:0.34') {
             exclude group: 'com.google.guava', module: 'guava'
             exclude group: 'junit', module: 'junit'
         }
-        testImplementation 'org.hamcrest:hamcrest-all:1.3'
         testImplementation("org.mockito:mockito-all:1.10.19") {
             exclude group: "org.ow2.asm", module: '*'
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,14 @@ kotlinTestVersion=1.2.71
 taskTreeVersion=1.3.1
 shadowVersion=6.1.0
 artifactoryVersion=4.21.0
+assertjVersion=3.22.0
 bndVersion=6.2.0
 
 kotlin.stdlib.default.dependency=false
 kotlin.incremental=true
 
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g -Dfile.encoding=UTF-8
+org.gradle.java.installations.auto-download=false
 org.gradle.caching=false
 org.gradle.daemon=false
 owasp.failOnError=false

--- a/quasar-core/src/main/java/co/paralleluniverse/common/resource/ClassLoaderUtil.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/resource/ClassLoaderUtil.java
@@ -33,17 +33,28 @@ package co.paralleluniverse.common.resource;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.PrivilegedAction;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+
+import static java.security.AccessController.doPrivileged;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableSet;
 
 /**
  *
@@ -54,10 +65,19 @@ public final class ClassLoaderUtil {
         void visit(String resource, URL url, ClassLoader cl) throws IOException;
     }
 
+    private static final String MODULE_INFO_CLASS = "module-info.class";
     private static final String CLASS_FILE_NAME_EXTENSION = ".class";
+    private static final String JAR_PROTOCOL = "jar";
 
     public static boolean isClassFile(String resourceName) {
-        return resourceName.endsWith(CLASS_FILE_NAME_EXTENSION);
+        return resourceName.endsWith(CLASS_FILE_NAME_EXTENSION) && !isModuleInfoClass(resourceName);
+    }
+
+    private static boolean isModuleInfoClass(String resourceName) {
+        final int modInfoLength = MODULE_INFO_CLASS.length();
+        final int resourceLength = resourceName.length();
+        return resourceName.endsWith(MODULE_INFO_CLASS)
+            && (resourceLength == modInfoLength || resourceName.charAt(resourceLength - modInfoLength - 1) == '/');
     }
 
     public static String classToResource(String className) {
@@ -194,26 +214,124 @@ public final class ClassLoaderUtil {
      * @return {@code loader}'s remotest parent that can still find {@code target}.
      */
     public static ClassLoader getBestClassLoader(ClassLoader loader, String resourceName, URL target) {
-        final ClassLoader extensionClassLoader = ClassLoader.getSystemClassLoader().getParent();
-        final ClassLoader bootstrapClassLoader = extensionClassLoader.getParent();
-        ClassLoader current = loader;
-        for (;;) {
-            ClassLoader next = current.getParent();
-            if (next == bootstrapClassLoader) {
-                if (current == extensionClassLoader) {
-                    break;
-                }
-                next = extensionClassLoader;
-            }
+        final ClassLoader bestCl = new BestLookup(resourceName, target).lookup(loader);
+        return (bestCl == null) ? loader : bestCl;
+    }
 
-            final URL resource = next.getResource(resourceName);
-            if (!target.equals(resource)) {
-                break;
-            }
-
-            current = next;
+    private static String getUnderlyingURL(URL url) {
+        if (JAR_PROTOCOL.equals(url.getProtocol())) {
+            // This is probably (but not necessarily) a file:/ URL.
+            final String file = url.getFile();
+            return file.substring(0, file.indexOf("!/"));
+        } else {
+            return url.toString();
         }
-        return current;
+    }
+
+    /**
+     * Worker class for {@link #getBestClassLoader(ClassLoader, String, URL)}.
+     * We need to search from the bootstrap classloader upwards in order to
+     * mirror how {@link ClassLoader#getResource(String)} works.
+     *
+     * We are expected already to be running with the correct security context.
+     */
+    private static final class BestLookup {
+        private static final Set<String> BOOT_CLASS_PATH = doPrivileged(new GetBootClassPath());
+
+        private final String resourceName;
+        private final URL target;
+        private final Predicate<String> underlyingMatcher;
+        private final ClassLoader extensionClassLoader;
+        private final ClassLoader bootstrapClassLoader;
+
+        BestLookup(String resourceName, URL resource) {
+            this.resourceName = resourceName;
+            this.target = resource;
+            String underlyingURL = getUnderlyingURL(target);
+            this.underlyingMatcher = underlyingURL.endsWith(CLASS_FILE_NAME_EXTENSION)
+                ? new IsEqualOrContains(underlyingURL) : new IsEqual(underlyingURL);
+            this.extensionClassLoader = ClassLoader.getSystemClassLoader().getParent();
+            this.bootstrapClassLoader = extensionClassLoader.getParent();
+        }
+
+        private static final class IsEqualOrContains implements Predicate<String> {
+            private final String underlyingURL;
+
+            IsEqualOrContains(String underlyingURL) {
+                this.underlyingURL = underlyingURL;
+            }
+
+            @Override
+            public boolean test(String url) {
+                return underlyingURL.equals(url) || (url.endsWith("/") && underlyingURL.startsWith(url));
+            }
+        }
+
+        private static final class IsEqual implements Predicate<String> {
+            private final String underlyingURL;
+
+            IsEqual(String underlyingURL) {
+                this.underlyingURL = underlyingURL;
+            }
+
+            @Override
+            public boolean test(String url) {
+                return underlyingURL.equals(url);
+            }
+        }
+
+        ClassLoader lookup(ClassLoader current) {
+            if (current == bootstrapClassLoader) {
+                if (BOOT_CLASS_PATH.isEmpty()) {
+                    // Fall-back strategy if sun.boot.class.path property unavailable.
+                    // This checks both the extension and bootstrap classloaders, but
+                    // we are hoping never to reach here in practice.
+                    final URL url = extensionClassLoader.getResource(resourceName);
+                    if (target.equals(url)) {
+                        return extensionClassLoader;
+                    }
+                } else if (isTargetFrom(BOOT_CLASS_PATH)) {
+                    // We are conflating the bootstrap and extension
+                    // classloaders as far as Quasar is concerned.
+                    return extensionClassLoader;
+                }
+            } else {
+                final ClassLoader candidate = lookup(current.getParent());
+                if (candidate != null) {
+                    return candidate;
+                }
+
+                if (current instanceof URLClassLoader) {
+                    // Important optimisation, because invoking getResource() is not cheap!
+                    // This also works for the application and extension classloaders on Java 8.
+                    if (isTargetFrom(((URLClassLoader) current).getURLs())) {
+                        return current;
+                    }
+                } else if (target.equals(current.getResource(resourceName))) {
+                    return current;
+                }
+            }
+            return null;
+        }
+
+        private boolean isTargetFrom(URL[] urls) {
+            for (URL url : urls) {
+                if (underlyingMatcher.test(url.toString())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @SuppressWarnings("SameParameterValue")
+        private boolean isTargetFrom(Iterable<String> paths) {
+            for (String path : paths) {
+                if (underlyingMatcher.test(path)) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     /**
@@ -258,6 +376,37 @@ public final class ClassLoaderUtil {
             return uri;
         else
             return new File(jarFile.getParentFile(), path.replace('/', File.separatorChar)).toURI();
+    }
+
+    /**
+     * Computes the URLs that the bootstrap classloader would use, if it
+     * were an instance of {@link URLClassLoader}. Note that the
+     * sun.boot.class.path system property is technically an undocumented
+     * implementation detail, and so we cannot be sure it will exist.
+     */
+    private static class GetBootClassPath implements PrivilegedAction<Set<String>> {
+        @Override
+        public Set<String> run() {
+            final String bootClassPath = System.getProperty("sun.boot.class.path");
+            if (bootClassPath == null || bootClassPath.isEmpty()) {
+                return emptySet();
+            }
+
+            try {
+                final String[] elements = bootClassPath.split(File.pathSeparator);
+                final Set<String> bootPath = new LinkedHashSet<>();
+                for (String element : elements) {
+                    final Path path = Paths.get(element);
+                    if (Files.exists(path)) {
+                        bootPath.add(path.toUri().toURL().toString());
+                    }
+                }
+                return unmodifiableSet(bootPath);
+            } catch (MalformedURLException e) {
+                System.err.println("[quasar] ERROR: Invalid sun.boot.class.path property - " + e.getMessage());
+                return emptySet();
+            }
+        }
     }
 
     private ClassLoaderUtil() {

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/GetExtensionClassLoader.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/GetExtensionClassLoader.java
@@ -1,0 +1,10 @@
+package co.paralleluniverse.fibers.instrument;
+
+import java.security.PrivilegedAction;
+
+final class GetExtensionClassLoader implements PrivilegedAction<ClassLoader> {
+    @Override
+    public ClassLoader run() {
+        return ClassLoader.getSystemClassLoader().getParent();
+    }
+}

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
@@ -81,15 +81,12 @@ import org.objectweb.asm.MethodVisitor;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.lang.instrument.Instrumentation;
-import java.lang.ref.WeakReference;
 import java.security.ProtectionDomain;
-import java.util.Collections;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static co.paralleluniverse.common.asm.ASMUtil.ASMAPI;
 import static co.paralleluniverse.fibers.instrument.Classes.FIBER_CLASS_NAME;
 import static co.paralleluniverse.fibers.instrument.Classes.isYieldMethod;
+import static java.security.AccessController.doPrivileged;
 
 /*
  * @author pron
@@ -99,7 +96,6 @@ import static co.paralleluniverse.fibers.instrument.Classes.isYieldMethod;
 public class JavaAgent {
     private static final String USAGE = "Usage: vdmcbx(exclusion;...)l(exclusion;...) (verbose, debug, allow monitors, check class, allow blocking)";
     private static volatile boolean ACTIVE;
-    private static final Set<WeakReference<ClassLoader>> classLoaders = Collections.newSetFromMap(new ConcurrentHashMap<WeakReference<ClassLoader>, Boolean>());
 
     public static void premain(String agentArguments, Instrumentation instrumentation) {
         if (!instrumentation.isRetransformClassesSupported()) {
@@ -196,7 +192,6 @@ public class JavaAgent {
 
         Retransform.instrumentation = instrumentation;
         Retransform.instrumentor = instrumentor;
-        Retransform.classLoaders = classLoaders;
 
         instrumentation.addTransformer(new Transformer(instrumentor), true);
     }
@@ -219,10 +214,7 @@ public class JavaAgent {
         @Override
         public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
             if (loader == null) {
-                loader = Thread.currentThread().getContextClassLoader();
-                if (loader == null) {
-                    loader = ClassLoader.getSystemClassLoader();
-                }
+                loader = doPrivileged(new GetExtensionClassLoader());
             }
 
             if (!instrumentor.shouldInstrument(loader)) {
@@ -236,8 +228,6 @@ public class JavaAgent {
                 return null;
 
             Retransform.beforeTransform(className, classBeingRedefined, classfileBuffer);
-
-            classLoaders.add(new WeakReference<>(loader));
 
             try {
                 final byte[] transformed = instrumentor.instrumentClass(loader, className, classfileBuffer);

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Log.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Log.java
@@ -32,7 +32,7 @@ package co.paralleluniverse.fibers.instrument;
  * @author Matthias Mann
  */
 public interface Log {
-    public void log(LogLevel level, String msg, Object ... args);
-    
-    public void error(String msg, Throwable ex);
+    void log(LogLevel level, String msg, Object ... args);
+
+    void error(String msg, Throwable ex);
 }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
@@ -79,16 +79,17 @@ import java.util.TreeMap;
 public final class MethodDatabase {
     private static final String JAVA_OBJECT = "java/lang/Object";
     private static final List<String> JDK_JAVAX_PACKAGES = unmodifiableList(asList(
-        "accessibility/", "annotation/",
-        "crypto", "imageio/",
-        "lang/", "management/",
-        "naming/", "net/",
-        "print/", "rmi/",
-        "script/", "security/",
-        "smartcardio/", "sound/",
-        "sql/", "swing/",
-        "tools/", "transaction/",
-        "xml/"
+        "accessibility/", "activation/",
+        "activity/", "annotation/",
+        "crypto/", "imageio/",
+        "jws/", "lang/",
+        "management/", "naming/",
+        "net/", "print/",
+        "rmi/", "script/",
+        "security/", "smartcardio/",
+        "sound/", "sql/",
+        "swing/", "tools/",
+        "transaction/", "xml/"
     ));
 
     private final WeakReference<ClassLoader> clRef;

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
@@ -43,6 +43,8 @@ package co.paralleluniverse.fibers.instrument;
 
 import static co.paralleluniverse.fibers.instrument.Classes.isYieldMethod;
 import static java.security.AccessController.doPrivileged;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
 
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
@@ -76,6 +78,18 @@ import java.util.TreeMap;
  */
 public final class MethodDatabase {
     private static final String JAVA_OBJECT = "java/lang/Object";
+    private static final List<String> JDK_JAVAX_PACKAGES = unmodifiableList(asList(
+        "accessibility/", "annotation/",
+        "crypto", "imageio/",
+        "lang/", "management/",
+        "naming/", "net/",
+        "print/", "rmi/",
+        "script/", "security/",
+        "smartcardio/", "sound/",
+        "sql/", "swing/",
+        "tools/", "transaction/",
+        "xml/"
+    ));
 
     private final WeakReference<ClassLoader> clRef;
     private final SuspendableClassifier classifier;
@@ -205,7 +219,7 @@ public final class MethodDatabase {
             return null;
         }
 
-        final ClassEntry entry = getClassEntry(className);
+        ClassEntry entry = getClassEntry(className);
         if (entry != null) {
             return new Pair<>(this, entry);
         } else {
@@ -215,7 +229,13 @@ public final class MethodDatabase {
                 return null;
             } else {
                 final MethodDatabase ownerDB = lookup.toOwnerDB(this);
-                return new Pair<>(ownerDB, ownerDB.fetchClassEntry(className, lookup.getResource()));
+                if (ownerDB != this) {
+                    entry = ownerDB.getClassEntry(className);
+                }
+                if (entry == null) {
+                    entry = ownerDB.loadClassEntry(className, lookup.getResource());
+                }
+                return new Pair<>(ownerDB, entry);
             }
         }
     }
@@ -304,7 +324,7 @@ public final class MethodDatabase {
     }
 
     void recordSuspendableMethods(String className, ClassEntry entry) {
-        ClassEntry oldEntry;
+        final ClassEntry oldEntry;
         synchronized(classes) {
             oldEntry = classes.put(className, entry);
         }
@@ -369,16 +389,14 @@ public final class MethodDatabase {
         }
     }
 
-    private ClassEntry fetchClassEntry(String className, URL resource) {
-        ClassEntry entry = getClassEntry(className);
-        if (entry == null) {
-            log(LogLevel.INFO, "Reading class: %s", className);
-            try (final InputStream is = privilegedOpenInputStream(resource)) {
-                entry = checkFileAndClose(is).getClassEntry();
-                recordSuspendableMethods(className, entry);
-            } catch(IOException e) {
-                throw new UncheckedIOException("While opening " + className, e);
-            }
+    private ClassEntry loadClassEntry(String className, URL resource) {
+        log(LogLevel.INFO, "Reading class: %s", className);
+        final ClassEntry entry;
+        try (final InputStream is = privilegedOpenInputStream(resource)) {
+            entry = checkFileAndClose(is).getClassEntry();
+            recordSuspendableMethods(className, entry);
+        } catch(IOException e) {
+            throw new UncheckedIOException("While opening " + className, e);
         }
         return entry;
     }
@@ -515,17 +533,7 @@ public final class MethodDatabase {
             return false;
         }
         final String classSubName = className.substring("javax/".length());
-        return classSubName.startsWith("activation/")
-                || classSubName.startsWith("crypto/")
-                || classSubName.startsWith("lang/")
-                || classSubName.startsWith("management/")
-                || classSubName.startsWith("naming/")
-                || classSubName.startsWith("net/")
-                || classSubName.startsWith("script/")
-                || classSubName.startsWith("security/")
-                || classSubName.startsWith("sql/")
-                || classSubName.startsWith("tools/")
-                || classSubName.startsWith("xml/");
+        return JDK_JAVAX_PACKAGES.stream().anyMatch(classSubName::startsWith);
     }
 
     public static boolean isProblematicClass(String className) {

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Retransform.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Retransform.java
@@ -21,11 +21,7 @@ import java.io.PrintWriter;
 import java.lang.instrument.ClassDefinition;
 import java.lang.instrument.Instrumentation;
 import java.lang.instrument.UnmodifiableClassException;
-import java.lang.ref.WeakReference;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -35,8 +31,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class Retransform {
     static volatile Instrumentation instrumentation;
     static volatile QuasarInstrumentor instrumentor;
-    static volatile Set<WeakReference<ClassLoader>> classLoaders = Collections.newSetFromMap(new ConcurrentHashMap<WeakReference<ClassLoader>, Boolean>());
-    
+
     private static final CopyOnWriteArrayList<ClassLoadListener> listeners = new CopyOnWriteArrayList<>();
 
     public static void retransform(Class<?> clazz) throws UnmodifiableClassException {
@@ -59,22 +54,6 @@ public class Retransform {
         return instrumentor;
     }
 
-//    public static boolean isInstrumented(String className) {
-//        for (Iterator<WeakReference<ClassLoader>> it = classLoaders.iterator(); it.hasNext();) {
-//            final WeakReference<ClassLoader> ref = it.next();
-//            final ClassLoader loader = ref.get();
-//            if (loader == null)
-//                it.remove();
-//            else {
-//                try {
-//                    if (isInstrumented(Class.forName(className, false, loader)))
-//                        return true;
-//                } catch (ClassNotFoundException ex) {
-//                }
-//            }
-//        }
-//        return false;
-//    }
     public static void addWaiver(String className, String methodName) {
         SuspendableHelper.addWaiver(className, methodName);
     }

--- a/quasar-core/src/test/java/co/paralleluniverse/common/resource/BestClassLoaderTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/common/resource/BestClassLoaderTest.java
@@ -1,6 +1,7 @@
 package co.paralleluniverse.common.resource;
 
 import co.paralleluniverse.common.test.ClassFactory;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.URL;
@@ -8,11 +9,18 @@ import java.util.List;
 
 import static co.paralleluniverse.common.resource.ClassLoaderUtil.classToResource;
 import static co.paralleluniverse.common.resource.ClassLoaderUtil.getBestClassLoader;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class BestClassLoaderTest {
     private static final ClassLoader EXTENSION_CLASSLOADER = ClassLoader.getSystemClassLoader().getParent();
+
+    @BeforeClass
+    public static void setup() {
+        assertNull("non-null bootstrap classloader", EXTENSION_CLASSLOADER.getParent());
+    }
 
     @Test
     public void testWithBootstrapClassLoaderAsParent() throws Exception {
@@ -57,6 +65,31 @@ public class BestClassLoaderTest {
         final URL junitResource = classLoader.getResource(junitResourceName);
         assertNotNull(junitResource);
         assertEquals(ClassLoader.getSystemClassLoader(), getBestClassLoader(classLoader, junitResourceName, junitResource));
+    }
+
+    @Test
+    public void testBootstrapClasspathExtension() throws Exception {
+        final Class<?> testClass = Class.forName("co.paralleluniverse.vtime.Clock", false, ClassLoader.getSystemClassLoader());
+        assertNull(testClass.getClassLoader());
+
+        final String testResourceName = classToResource(testClass);
+        final URL testResource = ClassLoader.getSystemClassLoader().getResource(testResourceName);
+        assertNotNull(testResource);
+        assertThat(testResource.toString())
+            .startsWith("jar:file:")
+            .endsWith("!/" + testResourceName);
+        assertEquals(EXTENSION_CLASSLOADER, getBestClassLoader(ClassLoader.getSystemClassLoader(), testResourceName, testResource));
+    }
+
+    @Test
+    public void testClassLoaderForFileResource() {
+        final ClassLoader classLoader = getClass().getClassLoader();
+
+        final String testClassResourceName = classToResource(getClass());
+        final URL testClassResource = classLoader.getResource(testClassResourceName);
+        assertNotNull(testClassResource);
+        assertEquals("file", testClassResource.getProtocol());
+        assertEquals(classLoader, getBestClassLoader(classLoader, testClassResourceName, testClassResource));
     }
 
     public interface NestedTemplate {

--- a/quasar-core/src/test/java/co/paralleluniverse/common/test/ClassFactory.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/common/test/ClassFactory.java
@@ -9,9 +9,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.security.ProtectionDomain;
+import java.util.Objects;
 
 import static co.paralleluniverse.common.asm.ASMUtil.ASMAPI;
 import static co.paralleluniverse.common.resource.ClassLoaderUtil.classToResource;
@@ -39,7 +40,7 @@ public final class ClassFactory {
         final byte[] byteCode = readAllBytes(templateResource.openStream());
         final ClassWriter writer = new ClassWriter(COMPUTE_MAXS);
         new ClassReader(byteCode).accept(new RenameVisitor(classToSlashed(className), writer), SKIP_DEBUG | SKIP_FRAMES);
-        return new ByteCodeClassLoader(className, writer.toByteArray(), parent).createClass();
+        return new ByteCodeClassLoader(className, writer.toByteArray(), template.getProtectionDomain(), parent).createClass();
     }
 
     private static byte[] readAllBytes(InputStream input) throws IOException {
@@ -66,42 +67,54 @@ public final class ClassFactory {
         }
     }
 
-    private static class ByteCodeClassLoader extends ClassLoader {
+    private static final class ByteCodeClassLoader extends ClassLoader {
         private final String resourceName;
         private final String className;
         private final byte[] byteCode;
+        private final ProtectionDomain pd;
 
-        ByteCodeClassLoader(String className, byte[] byteCode, ClassLoader parent) {
+        ByteCodeClassLoader(String className, byte[] byteCode, ProtectionDomain pd, ClassLoader parent) {
             super(parent);
             this.resourceName = classToResource(className);
             this.className = className;
             this.byteCode = byteCode;
+            this.pd = pd;
         }
 
         Class<?> createClass() {
-            Class<?> clazz = defineClass(className, byteCode, 0, byteCode.length);
+            Class<?> clazz = defineClass(className, byteCode, 0, byteCode.length, pd);
             resolveClass(clazz);
             return clazz;
         }
 
         @Override
-        public URL getResource(String name) {
+        protected URL findResource(String name) {
             if (resourceName.equals(name)) {
                 try {
                     return new URL("file", "bytecode", resourceName);
-                } catch (MalformedURLException e) {
-                    throw new UncheckedIOException(e);
+                } catch (MalformedURLException ignored) {
                 }
             }
-            return super.getResource(name);
+            return null;
         }
 
         @Override
         public InputStream getResourceAsStream(String name) {
-            if (resourceName.equals(name)) {
-                return new ByteArrayInputStream(byteCode);
+            Objects.requireNonNull(name);
+            final URL resource = getResource(name);
+            if (resource != null) {
+                if ("file".equals(resource.getProtocol())
+                        && "bytecode".equals(resource.getHost())
+                        && resourceName.equals(resource.getFile())) {
+                    return new ByteArrayInputStream(byteCode);
+                } else {
+                    try {
+                        return resource.openStream();
+                    } catch (IOException ignored) {
+                    }
+                }
             }
-            return super.getResourceAsStream(name);
+            return null;
         }
     }
 }

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/FiberAsyncTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/FiberAsyncTest.java
@@ -15,7 +15,6 @@ package co.paralleluniverse.fibers;
 
 import co.paralleluniverse.common.test.TestUtil;
 import co.paralleluniverse.common.util.CheckedCallable;
-import co.paralleluniverse.common.util.Debug;
 import co.paralleluniverse.strands.SuspendableRunnable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -24,13 +23,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
@@ -45,7 +42,7 @@ public class FiberAsyncTest {
     @Rule
     public TestRule watchman = TestUtil.WATCHMAN;
 
-    private FiberScheduler scheduler;
+    private final FiberScheduler scheduler;
 
     public FiberAsyncTest() {
         scheduler = new FiberForkJoinScheduler("test", 4, null, false);
@@ -149,7 +146,7 @@ public class FiberAsyncTest {
     }
 
     static abstract class MyFiberAsync extends FiberAsync<String, RuntimeException> implements MyCallback {
-        private final Fiber fiber;
+        private final Fiber<?> fiber;
 
         public MyFiberAsync() {
             this.fiber = Fiber.currentFiber();
@@ -168,11 +165,11 @@ public class FiberAsyncTest {
 
     @Test
     public void testSyncCallback() throws Exception {
-        final Fiber fiber = new Fiber(scheduler, new SuspendableRunnable() {
+        final Fiber<?> fiber = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 String res = callService(syncService);
-                assertThat(res, equalTo("sync result!"));
+                assertThat(res).isEqualTo("sync result!");
             }
         }).start();
 
@@ -181,14 +178,14 @@ public class FiberAsyncTest {
 
     @Test
     public void testSyncCallbackException() throws Exception {
-        final Fiber fiber = new Fiber(scheduler, new SuspendableRunnable() {
+        final Fiber<?> fiber = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution {
                 try {
                     String res = callService(badSyncService);
                     fail();
                 } catch (Exception e) {
-                    assertThat(e.getMessage(), equalTo("sync exception!"));
+                    assertThat(e.getMessage()).isEqualTo("sync exception!");
                 }
             }
         }).start();
@@ -198,11 +195,11 @@ public class FiberAsyncTest {
 
     @Test
     public void testAsyncCallback() throws Exception {
-        final Fiber fiber = new Fiber(scheduler, new SuspendableRunnable() {
+        final Fiber<?> fiber = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 String res = callService(asyncService);
-                assertThat(res, equalTo("async result!"));
+                assertThat(res).isEqualTo("async result!");
             }
         }).start();
 
@@ -211,14 +208,14 @@ public class FiberAsyncTest {
 
     @Test
     public void testAsyncCallbackException() throws Exception {
-        final Fiber fiber = new Fiber(scheduler, new SuspendableRunnable() {
+        final Fiber<?> fiber = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution {
                 try {
                     String res = callService(badAsyncService);
                     fail();
                 } catch (Exception e) {
-                    assertThat(e.getMessage(), equalTo("async exception!"));
+                    assertThat(e.getMessage()).isEqualTo("async exception!");
                 }
             }
         }).start();
@@ -228,7 +225,7 @@ public class FiberAsyncTest {
 
     @Test
     public void testAsyncCallbackExceptionInRequestAsync() throws Exception {
-        final Fiber fiber = new Fiber(scheduler, new SuspendableRunnable() {
+        final Fiber<?> fiber = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution {
                 try {
@@ -242,7 +239,7 @@ public class FiberAsyncTest {
                     }.run();
                     fail();
                 } catch (Exception e) {
-                    assertThat(e.getMessage(), equalTo("requestAsync exception!"));
+                    assertThat(e.getMessage()).isEqualTo("requestAsync exception!");
                 }
             }
         }).start();
@@ -252,12 +249,12 @@ public class FiberAsyncTest {
 
     @Test
     public void testTimedAsyncCallbackNoTimeout() throws Exception {
-        final Fiber fiber = new Fiber(scheduler, new SuspendableRunnable() {
+        final Fiber<?> fiber = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 try {
                     String res = callService(asyncService, 50, TimeUnit.MILLISECONDS);
-                    assertThat(res, equalTo("async result!"));
+                    assertThat(res).isEqualTo("async result!");
                 } catch (TimeoutException e) {
                     throw new RuntimeException();
                 }
@@ -269,7 +266,7 @@ public class FiberAsyncTest {
 
     @Test
     public void testTimedAsyncCallbackWithTimeout() throws Exception {
-        final Fiber fiber = new Fiber(scheduler, new SuspendableRunnable() {
+        final Fiber<?> fiber = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 try {
@@ -285,7 +282,7 @@ public class FiberAsyncTest {
 
     @Test
     public void testInterrupt1() throws Exception {
-        final Fiber fiber = new Fiber(scheduler, new SuspendableRunnable() {
+        final Fiber<?> fiber = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution {
                 try {
@@ -302,7 +299,7 @@ public class FiberAsyncTest {
 
     @Test
     public void testInterrupt2() throws Exception {
-        final Fiber fiber = new Fiber(scheduler, new SuspendableRunnable() {
+        final Fiber<?> fiber = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution {
                 try {
@@ -323,7 +320,7 @@ public class FiberAsyncTest {
         final AtomicBoolean started = new AtomicBoolean();
         final AtomicBoolean interrupted = new AtomicBoolean();
 
-        Fiber fiber = new Fiber(new SuspendableRunnable() {
+        Fiber<?> fiber = new Fiber<>(new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 FiberAsync.runBlocking(Executors.newSingleThreadExecutor(),
@@ -353,13 +350,13 @@ public class FiberAsyncTest {
                 fail("InterruptedException not thrown");
         }
         Thread.sleep(100);
-        assertThat(started.get(), is(true));
-        assertThat(interrupted.get(), is(true));
+        assertThat(started.get()).isTrue();
+        assertThat(interrupted.get()).isTrue();
     }
     
     @Test
     public void testRunBlocking() throws Exception {
-        final Fiber fiber = new Fiber(new SuspendableRunnable() {
+        final Fiber<?> fiber = new Fiber<>(new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 String res = FiberAsync.runBlocking(Executors.newCachedThreadPool(), new CheckedCallable<String, InterruptedException>() {
@@ -368,7 +365,7 @@ public class FiberAsyncTest {
                         return "ok";
                     }
                 });
-                assertThat(res, equalTo("ok"));
+                assertThat(res).isEqualTo("ok");
             }
         }).start();
 
@@ -377,7 +374,7 @@ public class FiberAsyncTest {
 
     @Test
     public void testRunBlockingWithTimeout1() throws Exception {
-        final Fiber fiber = new Fiber(new SuspendableRunnable() {
+        final Fiber<?> fiber = new Fiber<>(new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 try {
@@ -387,7 +384,7 @@ public class FiberAsyncTest {
                             return "ok";
                         }
                     });
-                    assertThat(res, equalTo("ok"));
+                    assertThat(res).isEqualTo("ok");
                 } catch (TimeoutException e) {
                     fail();
                 }
@@ -399,7 +396,7 @@ public class FiberAsyncTest {
 
     @Test
     public void testRunBlockingWithTimeout2() throws Exception {
-        final Fiber fiber = new Fiber(new SuspendableRunnable() {
+        final Fiber<?> fiber = new Fiber<>(new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 try {

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/ClassLoaderTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/ClassLoaderTest.java
@@ -167,6 +167,8 @@ public class ClassLoaderTest {
 
     @Test
     public void testClassesForCorrectMethodDatabase() throws Exception {
+        // Load a class from a boot classpath extension.
+        Class.forName("co.paralleluniverse.vtime.Clock", false, ClassLoader.getSystemClassLoader());
         try (URLClassLoader cl = createClassLoaderFor(getTestClassesURL())) {
             Class.forName(DYNAMIC_SUSPENDABLE_CLASS_NAME, false, cl);
             Class.forName(DYNAMIC_FIBER_CLASS_NAME, false, cl);

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/LeakTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/LeakTest.java
@@ -18,13 +18,12 @@ import co.paralleluniverse.fibers.Stack;
 import co.paralleluniverse.fibers.SuspendExecution;
 import co.paralleluniverse.fibers.TestsHelper;
 import co.paralleluniverse.strands.SuspendableRunnable;
-import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * See bug #282 (https://github.com/puniverse/quasar/issues/282)
@@ -34,7 +33,7 @@ public class LeakTest implements SuspendableRunnable {
     private static volatile String leaked = "leaked";
     @Test
     public void leaky() throws Exception {
-        Fiber co = new Fiber((String)null, null, this);
+        Fiber<?> co = new Fiber<>((String)null, null, this);
         
         leaked = "leaked";
         
@@ -49,7 +48,7 @@ public class LeakTest implements SuspendableRunnable {
         List<Object> stack = Arrays.asList((Object[])objectsField.get(stackField.get(co)));
         
 //        System.out.println(stack);
-        assertThat(stack, not(hasItem(leaked)));
+        assertThat(stack).doesNotContain(leaked);
 //        assertThat(stack, everyItem(nullValue()));
         
 //        WeakReference<String> ref = new WeakReference<>(leaked);

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/SuspendablesScannerTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/SuspendablesScannerTest.java
@@ -21,11 +21,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
-import static org.junit.Assert.*;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.objectweb.asm.Type;
+
+import static org.junit.Assert.assertTrue;
 
 public class SuspendablesScannerTest {
     private static SuspendablesScanner scanner;

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/FiberAsyncTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/FiberAsyncTest.kt
@@ -20,8 +20,7 @@ import co.paralleluniverse.fibers.FiberForkJoinScheduler
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.strands.Strand
 import co.paralleluniverse.strands.SuspendableRunnable
-import org.hamcrest.CoreMatchers.equalTo
-import org.junit.Assert.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
 import java.util.concurrent.Executors
@@ -125,7 +124,7 @@ class FiberAsyncTest {
     fun testSyncCallback() {
         val fiber = Fiber<Void>(scheduler, SuspendableRunnable @Suspendable {
             val res = callService(syncService)
-            assertThat(res, equalTo("sync result!"))
+            assertThat(res).isEqualTo("sync result!")
         }).start()
 
         fiber.join()
@@ -138,7 +137,7 @@ class FiberAsyncTest {
                 callService(badSyncService)
                 fail()
             } catch (e: Exception) {
-                assertThat(e.message, equalTo("sync exception!"))
+                assertThat(e.message).isEqualTo("sync exception!")
             }
         }).start()
 
@@ -149,7 +148,7 @@ class FiberAsyncTest {
     fun testAsyncCallback() {
         val fiber = Fiber<Void>(scheduler, SuspendableRunnable @Suspendable {
             val res = callService(asyncService)
-            assertThat(res, equalTo("async result!"))
+            assertThat(res).isEqualTo("async result!")
         }).start()
 
         fiber.join()
@@ -162,7 +161,7 @@ class FiberAsyncTest {
                 callService(badAsyncService)
                 fail()
             } catch (e: Exception) {
-                assertThat(e.message, equalTo("async exception!"))
+                assertThat(e.message).isEqualTo("async exception!")
             }
         }).start()
 
@@ -180,7 +179,7 @@ class FiberAsyncTest {
                 }.run()
                 fail()
             } catch (e: Exception) {
-                assertThat(e.message, equalTo("requestAsync exception!"))
+                assertThat(e.message).isEqualTo("requestAsync exception!")
             }
         }).start()
 
@@ -192,7 +191,7 @@ class FiberAsyncTest {
         val fiber = Fiber<Void>(scheduler, SuspendableRunnable @Suspendable {
             try {
                 val res = callService(asyncService, 100, TimeUnit.MILLISECONDS)
-                assertThat(res, equalTo("async result!"))
+                assertThat(res).isEqualTo("async result!")
             } catch (e: TimeoutException) {
                 throw RuntimeException()
             }
@@ -247,7 +246,7 @@ class FiberAsyncTest {
                 Strand.sleep(300)
                 "ok"
             })
-            assertThat(res, equalTo("ok"))
+            assertThat(res).isEqualTo("ok")
         }).start()
 
         fiber.join()
@@ -261,7 +260,7 @@ class FiberAsyncTest {
                     Strand.sleep(300)
                     "ok"
                 })
-                assertThat(res, equalTo("ok"))
+                assertThat(res).isEqualTo("ok")
             } catch (e: TimeoutException) {
                 fail()
             }


### PR DESCRIPTION
Avoid using `ClassLoader.getResource()` too many times, because this function is recursive and so potentially expensive to invoke inside a loop. We can optimise for the case when a `ClassLoader` is also a `URLClassLoader` by comparing the class resource URL with `URLClassLoader.getURLs()`. We can also recognise URLs belonging to the bootstrap classloader by examining the `sun.boot.class.path` system property (Java 8 and below).

Windows users: it might be worth checking this builds locally for you, to ensure the `sun.boot.class.path` handling is correct.