### PR TITLE
CORE-4839: Optimise the getBestClassLoader() algorithm.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,10 +119,8 @@ subprojects {
             exclude group: 'org.checkerframework', module: 'checker-qual'
         }
         timewarp 'co.paralleluniverse:timewarp:0.2.0-SNAPSHOT'
-        testImplementation 'org.hamcrest:hamcrest-all:1.3'
-        testImplementation('junit:junit:4.12') {
-            exclude group: 'org.hamcrest', module: '*'
-        }
+        testImplementation 'junit:junit:4.13.2'
+        testImplementation "org.assertj:assertj-core:$assertjVersion"
         testImplementation('com.google.truth:truth:0.42') {
             exclude group: 'com.google.guava', module: 'guava'
             exclude group: 'com.google.errorprone', module: '*'

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,5 +24,6 @@ osgiUtilFunctionVersion=1.1.0
 osgiUtilPromiseVersion=1.2.0
 
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g -Dfile.encoding=UTF-8
+org.gradle.java.installations.auto-download=false
 org.gradle.caching=false
 org.gradle.daemon=false

--- a/quasar-core/src/main/java/co/paralleluniverse/common/resource/ClassLoaderUtil.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/resource/ClassLoaderUtil.java
@@ -40,6 +40,7 @@ import java.net.URLClassLoader;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -54,10 +55,20 @@ public final class ClassLoaderUtil {
         void visit(String resource, URL url, ClassLoader cl) throws IOException;
     }
 
+    private static final String MODULE_INFO_CLASS = "module-info.class";
     private static final String CLASS_FILE_NAME_EXTENSION = ".class";
+    private static final String JAR_PROTOCOL = "jar";
+    private static final String JRT_PROTOCOL = "jrt";
 
     public static boolean isClassFile(String resourceName) {
-        return resourceName.endsWith(CLASS_FILE_NAME_EXTENSION) && !resourceName.endsWith("module-info.class");
+        return resourceName.endsWith(CLASS_FILE_NAME_EXTENSION) && !isModuleInfoClass(resourceName);
+    }
+
+    private static boolean isModuleInfoClass(String resourceName) {
+        final int modInfoLength = MODULE_INFO_CLASS.length();
+        final int resourceLength = resourceName.length();
+        return resourceName.endsWith(MODULE_INFO_CLASS)
+            && (resourceLength == modInfoLength || resourceName.charAt(resourceLength - modInfoLength - 1) == '/');
     }
 
     public static String classToResource(String className) {
@@ -200,26 +211,88 @@ public final class ClassLoaderUtil {
      * @return {@code loader}'s remotest parent that can still find {@code target}.
      */
     public static ClassLoader getBestClassLoader(ClassLoader loader, String resourceName, URL target) {
-        final ClassLoader platformClassLoader = ClassLoader.getPlatformClassLoader();
-        final ClassLoader bootstrapClassLoader = platformClassLoader.getParent();
-        ClassLoader current = loader;
-        for (;;) {
-            ClassLoader next = current.getParent();
-            if (next == bootstrapClassLoader) {
-                if (current == platformClassLoader) {
-                    break;
-                }
-                next = platformClassLoader;
-            }
-
-            final URL resource = next.getResource(resourceName);
-            if (!target.equals(resource)) {
-                break;
-            }
-
-            current = next;
+        if (JRT_PROTOCOL.equals(target.getProtocol())) {
+            // The URL format is jrt:/<module-name>/<module-resource-item>
+            final String jrtFile = target.getFile();
+            final String moduleName = jrtFile.substring(1, jrtFile.indexOf('/', 1));
+            final ClassLoader cl = ModuleLayer.boot().findLoader(moduleName);
+            final ClassLoader platformClassLoader = ClassLoader.getPlatformClassLoader();
+            return cl == platformClassLoader.getParent() ? platformClassLoader : cl;
+        } else {
+            final ClassLoader bestCl = new BestLookup(resourceName, target).lookup(loader);
+            return (bestCl == null) ? loader : bestCl;
         }
-        return current;
+    }
+
+    private static String getUnderlyingURL(URL url) {
+        if (JAR_PROTOCOL.equals(url.getProtocol())) {
+            // This is probably (but not necessarily) a file:/ URL.
+            final String file = url.getFile();
+            return file.substring(0, file.indexOf("!/"));
+        } else {
+            return url.toString();
+        }
+    }
+
+    /**
+     * Worker class for {@link #getBestClassLoader(ClassLoader, String, URL)}.
+     * We need to search from the bootstrap classloader upwards in order to
+     * mirror how {@link ClassLoader#getResource(String)} works.
+     *
+     * We are expected already to be running with the correct security context.
+     */
+    private static final class BestLookup {
+        private final String resourceName;
+        private final URL target;
+        private final Predicate<String> underlyingMatcher;
+        private final ClassLoader platformClassLoader;
+        private final ClassLoader bootstrapClassLoader;
+
+        BestLookup(String resourceName, URL resource) {
+            this.resourceName = resourceName;
+            this.target = resource;
+            final String underlyingURL = getUnderlyingURL(target);
+            this.underlyingMatcher = underlyingURL.endsWith(CLASS_FILE_NAME_EXTENSION)
+                ? u -> underlyingURL.equals(u) || (u.endsWith("/") && underlyingURL.startsWith(u))
+                : underlyingURL::equals;
+            this.platformClassLoader = ClassLoader.getPlatformClassLoader();
+            this.bootstrapClassLoader = platformClassLoader.getParent();
+        }
+
+        ClassLoader lookup(ClassLoader current) {
+            if (current == platformClassLoader || current == bootstrapClassLoader) {
+                // Support jars added via -Xbootclasspath/a:<jar>. This probably
+                // KILLS performance, but I cannot find any other way to search
+                // the JVM's entire boot classpath.
+                if (target.equals(platformClassLoader.getResource(resourceName))) {
+                    return platformClassLoader;
+                }
+            } else {
+                final ClassLoader candidate = lookup(current.getParent());
+                if (candidate != null) {
+                    return candidate;
+                }
+
+                if (current instanceof URLClassLoader) {
+                    // Important optimisation, because invoking getResource() is not cheap!
+                    if (isTargetFrom(((URLClassLoader) current).getURLs())) {
+                        return current;
+                    }
+                } else if (target.equals(current.getResource(resourceName))) {
+                    return current;
+                }
+            }
+            return null;
+        }
+
+        private boolean isTargetFrom(URL[] urls) {
+            for (URL url : urls) {
+                if (underlyingMatcher.test(url.toString())) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     /**

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
@@ -89,6 +89,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivilegedAction;
 import java.security.ProtectionDomain;
 import java.util.Arrays;
 import java.util.Set;
@@ -97,6 +98,7 @@ import static co.paralleluniverse.common.asm.ASMUtil.ASMAPI;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
+import static java.security.AccessController.doPrivileged;
 
 /*
  * @author pron
@@ -286,10 +288,7 @@ public class JavaAgent {
         @Override
         public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
             if (loader == null) {
-                loader = Thread.currentThread().getContextClassLoader();
-                if (loader == null) {
-                    loader = ClassLoader.getSystemClassLoader();
-                }
+                loader = doPrivileged((PrivilegedAction<ClassLoader>) ClassLoader::getPlatformClassLoader);
             }
 
             if (!instrumentor.shouldInstrument(loader)) {

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Log.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Log.java
@@ -33,6 +33,6 @@ package co.paralleluniverse.fibers.instrument;
  */
 public interface Log {
     void log(LogLevel level, String msg, Object ... args);
-    
+
     void error(String msg, Throwable ex);
 }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
@@ -62,7 +62,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
-import static co.paralleluniverse.common.resource.ClassLoaderUtil.getBestClassLoader;
 import static co.paralleluniverse.fibers.instrument.Classes.isYieldMethod;
 import static java.security.AccessController.doPrivileged;
 
@@ -76,9 +75,25 @@ import static java.security.AccessController.doPrivileged;
  * @author pron
  */
 public final class MethodDatabase {
-    public static final String JRT_PROTOCOL = "jrt";
-
     private static final String JAVA_OBJECT = "java/lang/Object";
+    private static final List<String> JDK_JAVAX_PACKAGES = List.of(
+        "accessibility/", "annotation/",
+        "crypto/", "imageio/",
+        "lang/", "management/",
+        "naming/", "net/",
+        "print/", "rmi/",
+        "script/", "security/",
+        "smartcardio/", "sound/",
+        "sql/", "swing/",
+        "tools/", "transaction/xa/",
+        "xml/"
+   );
+    private static final List<String> JDK_ORG_PACKAGES = List.of(
+        "w3c/dom/",
+        "xml/sax/",
+        "jcp/xml/",
+        "ietf/jgss/"
+    );
 
     private final WeakReference<ClassLoader> clRef;
     private final SuspendableClassifier classifier;
@@ -209,7 +224,7 @@ public final class MethodDatabase {
             return null;
         }
 
-        final ClassEntry entry = getClassEntry(className);
+        ClassEntry entry = getClassEntry(className);
         if (entry != null) {
             return new Pair<>(this, entry);
         } else {
@@ -219,7 +234,13 @@ public final class MethodDatabase {
                 return null;
             } else {
                 final MethodDatabase ownerDB = lookup.toOwnerDB(this);
-                return new Pair<>(ownerDB, ownerDB.fetchClassEntry(className, lookup.getResource()));
+                if (ownerDB != this) {
+                    entry = ownerDB.getClassEntry(className);
+                }
+                if (entry == null) {
+                    entry = ownerDB.loadClassEntry(className, lookup.getResource());
+                }
+                return new Pair<>(ownerDB, entry);
             }
         }
     }
@@ -308,7 +329,7 @@ public final class MethodDatabase {
     }
 
     void recordSuspendableMethods(String className, ClassEntry entry) {
-        ClassEntry oldEntry;
+        final ClassEntry oldEntry;
         synchronized(classes) {
             oldEntry = classes.put(className, entry);
         }
@@ -377,16 +398,14 @@ public final class MethodDatabase {
         }
     }
 
-    private ClassEntry fetchClassEntry(String className, URL resource) {
-        ClassEntry entry = getClassEntry(className);
-        if (entry == null) {
-            log(LogLevel.INFO, "Reading class: %s", className);
-            try (final InputStream is = privilegedOpenInputStream(resource)) {
-                entry = checkFileAndClose(is).getClassEntry();
-                recordSuspendableMethods(className, entry);
-            } catch(IOException e) {
-                throw new UncheckedIOException("While opening " + className, e);
-            }
+    private ClassEntry loadClassEntry(String className, URL resource) {
+        log(LogLevel.INFO, "Reading class: %s", className);
+        final ClassEntry entry;
+        try (final InputStream is = privilegedOpenInputStream(resource)) {
+            entry = checkFileAndClose(is).getClassEntry();
+            recordSuspendableMethods(className, entry);
+        } catch(IOException e) {
+            throw new UncheckedIOException("While opening " + className, e);
         }
         return entry;
     }
@@ -494,7 +513,7 @@ public final class MethodDatabase {
         MethodDatabase toOwnerDB(MethodDatabase db) {
             // Identify which classloader actually contains the byte-code for this class,
             // because its ClassEntry should belong to that classloader's MethodDatabase.
-            final ClassLoader ownerCl = doPrivileged((PrivilegedAction<? extends ClassLoader>) () ->
+            final ClassLoader ownerCl = doPrivileged((PrivilegedAction<? extends ClassLoader>)() ->
                 OSGiClassLoader.findResourceOwner(classloader).locate(classloader, resourceName, resource)
             );
             return (ownerCl == classloader) ? db : db.instrumentor.getMethodDatabase(ownerCl);
@@ -522,6 +541,8 @@ public final class MethodDatabase {
                || isJavaxInternal(className)
                || className.startsWith("sun/")
                || className.startsWith("jdk/")
+               || isOrgInternal(className)
+               || className.startsWith("netscape/javascript/")
                || (className.startsWith("com/sun/") && !className.startsWith("com/sun/jersey"));
     }
 
@@ -530,9 +551,15 @@ public final class MethodDatabase {
             return false;
         }
         final String classSubName = className.substring("javax/".length());
-        return classSubName.startsWith("crypto/")
-                || classSubName.startsWith("management/")
-                || classSubName.startsWith("net/");
+        return JDK_JAVAX_PACKAGES.stream().anyMatch(classSubName::startsWith);
+    }
+
+    private static boolean isOrgInternal(String className) {
+        if (!className.startsWith("org/")) {
+            return false;
+        }
+        final String classSubName = className.substring("org/".length());
+        return JDK_ORG_PACKAGES.stream().anyMatch(classSubName::startsWith);
     }
 
     public static boolean isProblematicClass(String className) {
@@ -542,21 +569,6 @@ public final class MethodDatabase {
                || className.startsWith("ch/qos/logback/")
                || className.startsWith("org/apache/logging/log4j/")
                || className.startsWith("org/apache/log4j/");
-    }
-
-    static ClassLoader getBestClassLoaderFor(ClassLoader cl, String resourceName, URL resource) {
-        if (resource != null) {
-            return doPrivileged((PrivilegedAction<? extends ClassLoader>)() -> {
-                if (JRT_PROTOCOL.equals(resource.getProtocol())) {
-                    // This resource is from the Java runtime base image.
-                    return ClassLoader.getPlatformClassLoader();
-                } else {
-                    // Get the first classloader in the hierarchy that can provide this resource.
-                    return getBestClassLoader(cl, resourceName, resource);
-                }
-            });
-        }
-        return cl;
     }
 
     public enum SuspendableType {

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/OSGiClassLoader.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/OSGiClassLoader.java
@@ -11,6 +11,7 @@ import java.util.function.BiPredicate;
 import java.util.regex.Pattern;
 
 import static co.paralleluniverse.common.resource.ClassLoaderUtil.classToResource;
+import static co.paralleluniverse.common.resource.ClassLoaderUtil.getBestClassLoader;
 import static java.security.AccessController.doPrivileged;
 
 /**
@@ -114,6 +115,10 @@ final class OSGiClassLoader extends ClassLoader {
         }
     }
 
+    private static ClassLoader fallbackFindResourceOwner(ClassLoader loader, String resourceName, URL resource) {
+        return resource == null ? loader : getBestClassLoader(loader, resourceName, resource);
+    }
+
     static synchronized BiPredicate<ClassLoader, Collection<Pattern>> fetchBundleLocationMatcher(ClassLoader cl) {
         if (bundleLocationExcluder == null) {
             bundleLocationExcluder = doPrivileged(
@@ -130,14 +135,14 @@ final class OSGiClassLoader extends ClassLoader {
                 createFindResourceOwner(cl)
             );
         }
-        return findResourceOwner != null ? findResourceOwner : MethodDatabase::getBestClassLoaderFor;
+        return findResourceOwner != null ? findResourceOwner : OSGiClassLoader::fallbackFindResourceOwner;
     }
 
     static synchronized void disable() {
         if (osgiLoader == null) {
             // Only disable OSGi support if it hasn't been activated yet.
             bundleLocationExcluder = FALSE;
-            findResourceOwner = MethodDatabase::getBestClassLoaderFor;
+            findResourceOwner = OSGiClassLoader::fallbackFindResourceOwner;
         }
     }
 }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/osgi/BundleLocator.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/osgi/BundleLocator.java
@@ -9,13 +9,10 @@ import org.osgi.framework.wiring.BundleWire;
 import org.osgi.framework.wiring.BundleWiring;
 
 import java.net.URL;
-import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Map;
 
 import static co.paralleluniverse.common.resource.ClassLoaderUtil.getBestClassLoader;
-import static co.paralleluniverse.fibers.instrument.MethodDatabase.JRT_PROTOCOL;
-import static java.security.AccessController.doPrivileged;
 
 /**
  * This class is not used directly because {@link ClassLoader#getSystemClassLoader()}
@@ -32,16 +29,8 @@ public final class BundleLocator {
     }
 
     private static ClassLoader findResourceOwner(ClassLoader cl, String resourceName, URL resource) {
-        return doPrivileged((PrivilegedAction<? extends ClassLoader>)() -> findResourceBundle(cl, resourceName, resource));
-    }
-
-    private static ClassLoader findResourceBundle(ClassLoader cl, String resourceName, URL resource) {
         if (resource != null) {
-            final String protocol = resource.getProtocol();
-            if (JRT_PROTOCOL.equals(protocol)) {
-                // This resource is from the Java runtime base image.
-                return ClassLoader.getPlatformClassLoader();
-            } else if (BUNDLE_PROTOCOL.equals(protocol) && (cl instanceof BundleReference)) {
+            if (BUNDLE_PROTOCOL.equals(resource.getProtocol()) && (cl instanceof BundleReference)) {
                 final Bundle bundle = ((BundleReference) cl).getBundle();
                 final BundleWiring wiring = new WiringView(resourceName, resource).getBundleWiring(bundle);
                 if (wiring != null) {

--- a/quasar-core/src/test/java/co/paralleluniverse/common/resource/BestClassLoaderTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/common/resource/BestClassLoaderTest.java
@@ -1,18 +1,41 @@
 package co.paralleluniverse.common.resource;
 
 import co.paralleluniverse.common.test.ClassFactory;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
 import static co.paralleluniverse.common.resource.ClassLoaderUtil.classToResource;
 import static co.paralleluniverse.common.resource.ClassLoaderUtil.getBestClassLoader;
+import static co.paralleluniverse.common.resource.ClassLoaderUtil.isClassFile;
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class BestClassLoaderTest {
-    private static final ClassLoader EXTENSION_CLASSLOADER = ClassLoader.getSystemClassLoader().getParent();
+    private static final ClassLoader PLATFORM_CLASSLOADER = ClassLoader.getPlatformClassLoader();
+    private static final String FILE_PROTOCOL = "file";
+    private static final String JRT_MODULES = "modules";
+    private static final String JRT_PROTOCOL = "jrt";
+    private static final String JRT_FS = "jrt:/";
+
+    @BeforeClass
+    public static void setup() {
+        assertNull("non-null bootstrap classloader", PLATFORM_CLASSLOADER.getParent());
+    }
 
     @Test
     public void testWithBootstrapClassLoaderAsParent() throws Exception {
@@ -31,7 +54,7 @@ public class BestClassLoaderTest {
         final String javaResourceName = classToResource(List.class);
         final URL javaResource = classLoader.getResource(javaResourceName);
         assertNotNull(javaResource);
-        assertEquals(EXTENSION_CLASSLOADER, getBestClassLoader(classLoader, javaResourceName, javaResource));
+        assertEquals(PLATFORM_CLASSLOADER, getBestClassLoader(classLoader, javaResourceName, javaResource));
     }
 
     @Test
@@ -51,12 +74,78 @@ public class BestClassLoaderTest {
         final String javaResourceName = classToResource(List.class);
         final URL javaResource = classLoader.getResource(javaResourceName);
         assertNotNull(javaResource);
-        assertEquals(EXTENSION_CLASSLOADER, getBestClassLoader(classLoader, javaResourceName, javaResource));
+        assertEquals(PLATFORM_CLASSLOADER, getBestClassLoader(classLoader, javaResourceName, javaResource));
 
         final String junitResourceName = classToResource(Test.class);
         final URL junitResource = classLoader.getResource(junitResourceName);
         assertNotNull(junitResource);
         assertEquals(ClassLoader.getSystemClassLoader(), getBestClassLoader(classLoader, junitResourceName, junitResource));
+    }
+
+    @Test
+    public void testBootstrapClasspathExtension() throws Exception {
+        final Class<?> testClass = Class.forName("co.paralleluniverse.vtime.Clock", false, ClassLoader.getSystemClassLoader());
+        assertNull(testClass.getClassLoader());
+
+        final String testResourceName = classToResource(testClass);
+        final URL testResource = ClassLoader.getSystemClassLoader().getResource(testResourceName);
+        assertNotNull(testResource);
+        assertThat(testResource.toString())
+            .startsWith("jar:file:")
+            .endsWith("!/" + testResourceName);
+        assertEquals(PLATFORM_CLASSLOADER, getBestClassLoader(ClassLoader.getSystemClassLoader(), testResourceName, testResource));
+    }
+
+    @Test
+    public void testClassLoaderForFileResource() {
+        final ClassLoader classLoader = getClass().getClassLoader();
+
+        final String testClassResourceName = classToResource(getClass());
+        final URL testClassResource = classLoader.getResource(testClassResourceName);
+        assertNotNull(testClassResource);
+        assertEquals(FILE_PROTOCOL, testClassResource.getProtocol());
+        assertEquals(classLoader, getBestClassLoader(classLoader, testClassResourceName, testClassResource));
+    }
+
+    @Test
+    public void testBestClassLoaderForJavaRuntimeImage() throws IOException {
+        final FileSystem jrt = FileSystems.getFileSystem(URI.create(JRT_FS));
+        final Set<String> moduleNames = Files.walk(jrt.getPath(JRT_MODULES))
+            .filter(p -> p.getNameCount() > 2)
+            .filter(p -> isClassFile(p.toString()))
+            .map(p -> {
+                // Path has format /modules/<module-name>/<resource-item-path>
+                final String moduleName = p.getName(1).toString();
+                final Optional<Module> module = ModuleLayer.boot().findModule(moduleName);
+                if (module.isPresent()) {
+                    final String path = p.toString();
+                    final String resourceName = path.substring(2 + JRT_MODULES.length() + moduleName.length());
+                    final URL resource = ClassLoader.getSystemResource(resourceName);
+                    assertNotNull(resourceName + " not found", resource);
+                    assertEquals(JRT_PROTOCOL, resource.getProtocol());
+
+                    final ClassLoader best = getBestClassLoader(ClassLoader.getSystemClassLoader(), resourceName, resource);
+                    assertEquals(path + " has incorrect best classloader", getClassLoaderForModule(moduleName), best);
+                    assertEquals(resource, best.getResource(resourceName));
+                    return moduleName;
+                } else {
+                    return null;
+                }
+            }).filter(Objects::nonNull)
+            .collect(toUnmodifiableSet());
+
+        // Check we tested what we were expecting to test.
+        assertThat(moduleNames)
+            .hasSizeGreaterThan(2)
+            .anySatisfy(name ->
+                assertTrue(name.startsWith("java.")))
+            .anySatisfy(name ->
+                assertTrue(name.startsWith("jdk.")));
+    }
+
+    private static ClassLoader getClassLoaderForModule(String moduleName) {
+        final ClassLoader cl = ModuleLayer.boot().findLoader(moduleName);
+        return cl == null ? PLATFORM_CLASSLOADER : cl;
     }
 
     public interface NestedTemplate {

--- a/quasar-core/src/test/java/co/paralleluniverse/common/resource/ClassLoaderUtilTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/common/resource/ClassLoaderUtilTest.java
@@ -1,0 +1,22 @@
+package co.paralleluniverse.common.resource;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ClassLoaderUtilTest {
+    @Test
+    public void testModuleInfoAsClass() {
+        assertFalse(ClassLoaderUtil.isClassFile("module-info.class"));
+        assertFalse(ClassLoaderUtil.isClassFile("/module-info.class"));
+        assertFalse(ClassLoaderUtil.isClassFile("/path/module-info.class"));
+    }
+
+    @Test
+    public void testAlmostModuleInfoAsClass() {
+        assertTrue(ClassLoaderUtil.isClassFile("not-module-info.class"));
+        assertTrue(ClassLoaderUtil.isClassFile("/not-module-info.class"));
+        assertTrue(ClassLoaderUtil.isClassFile("/path/not-module-info.class"));
+    }
+}

--- a/quasar-core/src/test/java/co/paralleluniverse/common/test/ClassFactory.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/common/test/ClassFactory.java
@@ -8,9 +8,10 @@ import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.security.ProtectionDomain;
+import java.util.Objects;
 
 import static co.paralleluniverse.common.asm.ASMUtil.ASMAPI;
 import static co.paralleluniverse.common.resource.ClassLoaderUtil.classToResource;
@@ -35,7 +36,7 @@ public final class ClassFactory {
         final byte[] byteCode = templateResource.openStream().readAllBytes();
         final ClassWriter writer = new ClassWriter(COMPUTE_MAXS);
         new ClassReader(byteCode).accept(new RenameVisitor(classToSlashed(className), writer), SKIP_DEBUG | SKIP_FRAMES);
-        return new ByteCodeClassLoader(className, writer.toByteArray(), parent).createClass();
+        return new ByteCodeClassLoader(className, writer.toByteArray(), template.getProtectionDomain(), parent).createClass();
     }
 
     private static class RenameVisitor extends ClassVisitor {
@@ -52,42 +53,54 @@ public final class ClassFactory {
         }
     }
 
-    private static class ByteCodeClassLoader extends ClassLoader {
+    private static final class ByteCodeClassLoader extends ClassLoader {
         private final String resourceName;
         private final String className;
         private final byte[] byteCode;
+        private final ProtectionDomain pd;
 
-        ByteCodeClassLoader(String className, byte[] byteCode, ClassLoader parent) {
+        ByteCodeClassLoader(String className, byte[] byteCode, ProtectionDomain pd, ClassLoader parent) {
             super(parent);
             this.resourceName = classToResource(className);
             this.className = className;
             this.byteCode = byteCode;
+            this.pd = pd;
         }
 
         Class<?> createClass() {
-            Class<?> clazz = defineClass(className, byteCode, 0, byteCode.length);
+            Class<?> clazz = defineClass(className, byteCode, 0, byteCode.length, pd);
             resolveClass(clazz);
             return clazz;
         }
 
         @Override
-        public URL getResource(String name) {
+        protected URL findResource(String name) {
             if (resourceName.equals(name)) {
                 try {
                     return new URL("file", "bytecode", resourceName);
-                } catch (MalformedURLException e) {
-                    throw new UncheckedIOException(e);
+                } catch (MalformedURLException ignored) {
                 }
             }
-            return super.getResource(name);
+            return null;
         }
 
         @Override
         public InputStream getResourceAsStream(String name) {
-            if (resourceName.equals(name)) {
-                return new ByteArrayInputStream(byteCode);
+            Objects.requireNonNull(name);
+            final URL resource = getResource(name);
+            if (resource != null) {
+                if ("file".equals(resource.getProtocol())
+                        && "bytecode".equals(resource.getHost())
+                        && resourceName.equals(resource.getFile())) {
+                    return new ByteArrayInputStream(byteCode);
+                } else {
+                    try {
+                        return resource.openStream();
+                    } catch (IOException ignored) {
+                    }
+                }
             }
-            return super.getResourceAsStream(name);
+            return null;
         }
     }
 }

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/FiberAsyncTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/FiberAsyncTest.java
@@ -24,16 +24,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  *
@@ -172,7 +169,7 @@ public class FiberAsyncTest {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 String res = callService(syncService);
-                assertThat(res, equalTo("sync result!"));
+                assertThat(res).isEqualTo("sync result!");
             }
         }).start();
 
@@ -188,7 +185,7 @@ public class FiberAsyncTest {
                     String res = callService(badSyncService);
                     fail();
                 } catch (Exception e) {
-                    assertThat(e.getMessage(), equalTo("sync exception!"));
+                    assertThat(e.getMessage()).isEqualTo("sync exception!");
                 }
             }
         }).start();
@@ -202,7 +199,7 @@ public class FiberAsyncTest {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 String res = callService(asyncService);
-                assertThat(res, equalTo("async result!"));
+                assertThat(res).isEqualTo("async result!");
             }
         }).start();
 
@@ -218,7 +215,7 @@ public class FiberAsyncTest {
                     String res = callService(badAsyncService);
                     fail();
                 } catch (Exception e) {
-                    assertThat(e.getMessage(), equalTo("async exception!"));
+                    assertThat(e.getMessage()).isEqualTo("async exception!");
                 }
             }
         }).start();
@@ -242,7 +239,7 @@ public class FiberAsyncTest {
                     }.run();
                     fail();
                 } catch (Exception e) {
-                    assertThat(e.getMessage(), equalTo("requestAsync exception!"));
+                    assertThat(e.getMessage()).isEqualTo("requestAsync exception!");
                 }
             }
         }).start();
@@ -257,7 +254,7 @@ public class FiberAsyncTest {
             public void run() throws SuspendExecution, InterruptedException {
                 try {
                     String res = callService(asyncService, 50, TimeUnit.MILLISECONDS);
-                    assertThat(res, equalTo("async result!"));
+                    assertThat(res).isEqualTo("async result!");
                 } catch (TimeoutException e) {
                     throw new RuntimeException();
                 }
@@ -353,8 +350,8 @@ public class FiberAsyncTest {
                 fail("InterruptedException not thrown");
         }
         Thread.sleep(100);
-        assertThat(started.get(), is(true));
-        assertThat(interrupted.get(), is(true));
+        assertThat(started.get()).isTrue();
+        assertThat(interrupted.get()).isTrue();
     }
     
     @Test
@@ -368,7 +365,7 @@ public class FiberAsyncTest {
                         return "ok";
                     }
                 });
-                assertThat(res, equalTo("ok"));
+                assertThat(res).isEqualTo("ok");
             }
         }).start();
 
@@ -387,7 +384,7 @@ public class FiberAsyncTest {
                             return "ok";
                         }
                     });
-                    assertThat(res, equalTo("ok"));
+                    assertThat(res).isEqualTo("ok");
                 } catch (TimeoutException e) {
                     fail();
                 }

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/FiberTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/FiberTest.java
@@ -14,7 +14,6 @@
 package co.paralleluniverse.fibers;
 
 import co.paralleluniverse.common.test.TestUtil;
-import co.paralleluniverse.common.util.Debug;
 import co.paralleluniverse.common.util.Exceptions;
 import co.paralleluniverse.fibers.suspend.SuspendExecution;
 import co.paralleluniverse.io.serialization.ByteArraySerializer;
@@ -39,11 +38,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.hamcrest.CoreMatchers.*;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Rule;
@@ -52,6 +49,11 @@ import org.junit.rules.TestRule;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  *
@@ -64,7 +66,7 @@ public class FiberTest implements Serializable {
     @Rule
     public TestRule watchman = TestUtil.WATCHMAN;
 
-    private transient FiberScheduler scheduler;
+    private final transient FiberScheduler scheduler;
 
 //    public FiberTest() {
 ////        this.scheduler = new FiberExecutorScheduler("test", Executors.newFixedThreadPool(1)); 
@@ -122,10 +124,10 @@ public class FiberTest implements Serializable {
             }
         });
 
-        assertThat(fiber.getPriority(), is(Strand.NORM_PRIORITY));
+        assertThat(fiber.getPriority()).isEqualTo(Strand.NORM_PRIORITY);
         
         fiber.setPriority(3);
-        assertThat(fiber.getPriority(), is(3));
+        assertThat(fiber.getPriority()).isEqualTo(3);
         
         try {
             fiber.setPriority(Strand.MAX_PRIORITY + 1);
@@ -182,8 +184,8 @@ public class FiberTest implements Serializable {
 
         int res = fiber2.get();
 
-        assertThat(res, is(123));
-        assertThat(fiber1.get(), is(123));
+        assertThat(res).isEqualTo(123);
+        assertThat(fiber1.get()).isEqualTo(123);
     }
 
     @Test
@@ -225,8 +227,8 @@ public class FiberTest implements Serializable {
         Thread.sleep(20);
         fiber.cancel(true);
         fiber.join(5, TimeUnit.MILLISECONDS);
-        assertThat(started.get(), is(true));
-        assertThat(terminated.get(), is(true));
+        assertThat(started.get()).isEqualTo(true);
+        assertThat(terminated.get()).isEqualTo(true);
     }
 
     @Test
@@ -254,8 +256,8 @@ public class FiberTest implements Serializable {
             fail();
         } catch (CancellationException e) {
         }
-        assertThat(started.get(), is(false));
-        assertThat(terminated.get(), is(false));
+        assertThat(started.get()).isFalse();
+        assertThat(terminated.get()).isFalse();
     }
 
     @Test
@@ -268,26 +270,26 @@ public class FiberTest implements Serializable {
         Fiber<?> fiber = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                assertThat(tl1.get(), is(nullValue()));
-                assertThat(tl2.get(), is("bar"));
+                assertThat(tl1.get()).isNull();
+                assertThat(tl2.get()).isEqualTo("bar");
 
                 tl1.set("koko");
                 tl2.set("bubu");
 
-                assertThat(tl1.get(), is("koko"));
-                assertThat(tl2.get(), is("bubu"));
+                assertThat(tl1.get()).isEqualTo("koko");
+                assertThat(tl2.get()).isEqualTo("bubu");
 
                 Fiber.sleep(100);
 
-                assertThat(tl1.get(), is("koko"));
-                assertThat(tl2.get(), is("bubu"));
+                assertThat(tl1.get()).isEqualTo("koko");
+                assertThat(tl2.get()).isEqualTo("bubu");
             }
         });
         fiber.start();
         fiber.join();
 
-        assertThat(tl1.get(), is("foo"));
-        assertThat(tl2.get(), is("bar"));
+        assertThat(tl1.get()).isEqualTo("foo");
+        assertThat(tl2.get()).isEqualTo("bar");
     }
     
     @Test
@@ -300,21 +302,21 @@ public class FiberTest implements Serializable {
         Fiber<?> fiber = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                assertThat(tl1.get(), is(nullValue()));
-                assertThat(tl2.get(), is(nullValue()));
+                assertThat(tl1.get()).isNull();
+                assertThat(tl2.get()).isNull();
 
                 tl1.set("koko");
                 tl2.set("bubu");
 
-                assertThat(tl1.get(), is("koko"));
-                assertThat(tl2.get(), is("bubu"));
+                assertThat(tl1.get()).isEqualTo("koko");
+                assertThat(tl2.get()).isEqualTo("bubu");
             }
         }).setNoLocals(true);
         fiber.start();
         fiber.join();
 
-        assertThat(tl1.get(), is("foo"));
-        assertThat(tl2.get(), is("bar"));
+        assertThat(tl1.get()).isEqualTo("foo");
+        assertThat(tl2.get()).isEqualTo("bar");
     }
 
     @Test
@@ -325,25 +327,25 @@ public class FiberTest implements Serializable {
         Fiber<?> fiber = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                assertThat(tl1.get(), is("foo"));
+                assertThat(tl1.get()).isEqualTo("foo");
 
                 Fiber.sleep(100);
 
-                assertThat(tl1.get(), is("foo"));
+                assertThat(tl1.get()).isEqualTo("foo");
 
                 tl1.set("koko");
 
-                assertThat(tl1.get(), is("koko"));
+                assertThat(tl1.get()).isEqualTo("koko");
 
                 Fiber.sleep(100);
 
-                assertThat(tl1.get(), is("koko"));
+                assertThat(tl1.get()).isEqualTo("koko");
             }
         });
         fiber.inheritThreadLocals().start();
         fiber.join();
 
-        assertThat(tl1.get(), is("foo"));
+        assertThat(tl1.get()).isEqualTo("foo");
     }
     
     
@@ -363,9 +365,9 @@ public class FiberTest implements Serializable {
                     for (int j = 0; j < loops; j++) {
                         final String tlValue = "tl-" + id + "-" + j;
                         tl.set(tlValue);
-                        assertThat(tl.get(), equalTo(tlValue));
+                        assertThat(tl.get()).isEqualTo(tlValue);
                         Strand.sleep(10);
-                        assertThat(tl.get(), equalTo(tlValue));
+                        assertThat(tl.get()).isEqualTo(tlValue);
                     }
                 }
             });
@@ -393,9 +395,9 @@ public class FiberTest implements Serializable {
                     for (int j = 0; j < loops; j++) {
                         final String tlValue = "tl-" + id + "-" + j;
                         tl.set(tlValue);
-                        assertThat(tl.get(), equalTo(tlValue));
+                        assertThat(tl.get()).isEqualTo(tlValue);
                         Strand.sleep(10);
-                        assertThat(tl.get(), equalTo(tlValue));
+                        assertThat(tl.get()).isEqualTo(tlValue);
                     }
                 }
             }).inheritThreadLocals();
@@ -420,7 +422,7 @@ public class FiberTest implements Serializable {
         });
 
         StackTraceElement[] st = fiber.getStackTrace();
-        assertThat(st, is(nullValue()));
+        assertThat(st).isNull();
     }
 
     @Test
@@ -438,7 +440,7 @@ public class FiberTest implements Serializable {
         fiber.join();
 
         StackTraceElement[] st = fiber.getStackTrace();
-        assertThat(st, is(nullValue()));
+        assertThat(st).isNull();
     }
 
     @Test
@@ -453,10 +455,10 @@ public class FiberTest implements Serializable {
                 StackTraceElement[] st = Fiber.currentFiber().getStackTrace();
 
                 // Strand.printStackTrace(st, System.err);
-                assertThat(st[0].getMethodName(), equalTo("getStackTrace"));
-                assertThat(st[1].getMethodName(), equalTo("foo"));
-                assertThat(st[st.length - 1].getMethodName(), equalTo("run"));
-                assertThat(st[st.length - 1].getClassName(), equalTo(Fiber.class.getName()));
+                assertThat(st[0].getMethodName()).isEqualTo("getStackTrace");
+                assertThat(st[1].getMethodName()).isEqualTo("foo");
+                assertThat(st[st.length - 1].getMethodName()).isEqualTo("run");
+                assertThat(st[st.length - 1].getClassName()).isEqualTo(Fiber.class.getName());
             }
         }).start();
 
@@ -492,9 +494,9 @@ public class FiberTest implements Serializable {
                 break;
             }
         }
-        assertThat(found, is(true));
-        assertThat(st[st.length - 1].getMethodName(), equalTo("run"));
-        assertThat(st[st.length - 1].getClassName(), equalTo(Fiber.class.getName()));
+        assertThat(found).isTrue();
+        assertThat(st[st.length - 1].getMethodName()).isEqualTo("run");
+        assertThat(st[st.length - 1].getClassName()).isEqualTo(Fiber.class.getName());
 
         fiber.join();
     }
@@ -526,7 +528,7 @@ public class FiberTest implements Serializable {
         StackTraceElement[] st = fiber.getStackTrace();
 
         // Strand.printStackTrace(st, System.err);
-        assertThat(st[0].getMethodName(), equalTo("park"));
+        assertThat(st[0].getMethodName()).isEqualTo("park");
         boolean found = false;
         for (StackTraceElement ste : st) {
             if (ste.getMethodName().equals("foo")) {
@@ -534,9 +536,9 @@ public class FiberTest implements Serializable {
                 break;
             }
         }
-        assertThat(found, is(true));
-        assertThat(st[st.length - 1].getMethodName(), equalTo("run"));
-        assertThat(st[st.length - 1].getClassName(), equalTo(Fiber.class.getName()));
+        assertThat(found).isTrue();
+        assertThat(st[st.length - 1].getMethodName()).isEqualTo("run");
+        assertThat(st[st.length - 1].getClassName()).isEqualTo(Fiber.class.getName());
 
         flag.set(true);
         cond.signalAll();
@@ -574,7 +576,7 @@ public class FiberTest implements Serializable {
                 StackTraceElement[] st = fiber.getStackTrace();
 
                 // Strand.printStackTrace(st, System.err);
-                assertThat(st[0].getMethodName(), equalTo("park"));
+                assertThat(st[0].getMethodName()).isEqualTo("park");
                 boolean found = false;
                 for (StackTraceElement ste : st) {
                     if (ste.getMethodName().equals("foo")) {
@@ -582,9 +584,9 @@ public class FiberTest implements Serializable {
                         break;
                     }
                 }
-                assertThat(found, is(true));
-                assertThat(st[st.length - 1].getMethodName(), equalTo("run"));
-                assertThat(st[st.length - 1].getClassName(), equalTo(Fiber.class.getName()));
+                assertThat(found).isTrue();
+                assertThat(st[st.length - 1].getMethodName()).isEqualTo("run");
+                assertThat(st[st.length - 1].getClassName()).isEqualTo(Fiber.class.getName());
             }
         }).start();
 
@@ -615,7 +617,7 @@ public class FiberTest implements Serializable {
         StackTraceElement[] st = fiber.getStackTrace();
 
         // Strand.printStackTrace(st, System.err);
-        assertThat(st[0].getMethodName(), equalTo("sleep"));
+        assertThat(st[0].getMethodName()).isEqualTo("sleep");
         boolean found = false;
         for (int i = 0; i < st.length; i++) {
             if (st[i].getMethodName().equals("foo")) {
@@ -623,9 +625,9 @@ public class FiberTest implements Serializable {
                 break;
             }
         }
-        assertThat(found, is(true));
-        assertThat(st[st.length - 1].getMethodName(), equalTo("run"));
-        assertThat(st[st.length - 1].getClassName(), equalTo(Fiber.class.getName()));
+        assertThat(found).isTrue();
+        assertThat(st[st.length - 1].getMethodName()).isEqualTo("run");
+        assertThat(st[st.length - 1].getClassName()).isEqualTo(Fiber.class.getName());
 
         fiber.join();
     }
@@ -680,10 +682,10 @@ public class FiberTest implements Serializable {
             f.join();
             fail();
         } catch (ExecutionException e) {
-            assertThat(e.getCause().getMessage(), equalTo("foo"));
+            assertThat(e.getCause().getMessage()).isEqualTo("foo");
         }
 
-        assertThat(t.get().getMessage(), equalTo("foo"));
+        assertThat(t.get().getMessage()).isEqualTo("foo");
     }
 
     @Test
@@ -711,12 +713,12 @@ public class FiberTest implements Serializable {
             f.join();
             fail();
         } catch (ExecutionException e) {
-            assertThat(e.getCause().getMessage(), equalTo("foo"));
+            assertThat(e.getCause().getMessage()).isEqualTo("foo");
         }
         final Throwable th = t.get();
 
         assertNotNull(th);
-        assertThat(th.getMessage(), equalTo("foo"));
+        assertThat(th.getMessage()).isEqualTo("foo");
     }
 
     @Test
@@ -735,7 +737,7 @@ public class FiberTest implements Serializable {
         }
 
         final List<String> results = FiberUtil.get(fibers);
-        assertThat(results, equalTo(expectedResults));
+        assertThat(results).isEqualTo(expectedResults);
     }
 
     @Test
@@ -754,7 +756,7 @@ public class FiberTest implements Serializable {
         }
 
         final List<String> results = FiberUtil.get(1, TimeUnit.SECONDS, fibers);
-        assertThat(results, equalTo(expectedResults));
+        assertThat(results).isEqualTo(expectedResults);
     }
 
     @Test(expected = TimeoutException.class)
@@ -773,7 +775,7 @@ public class FiberTest implements Serializable {
         }
 
         final List<String> results = FiberUtil.get(0, TimeUnit.SECONDS, fibers);
-        assertThat(results, equalTo(expectedResults));
+        assertThat(results).isEqualTo(expectedResults);
     }
 
     @Test(expected = TimeoutException.class)
@@ -795,7 +797,7 @@ public class FiberTest implements Serializable {
 
         // must be less than 60 (3 * 20) or else the test could sometimes pass.
         final List<String> results = FiberUtil.get(55, TimeUnit.MILLISECONDS, fibers);
-        assertThat(results, equalTo(expectedResults));
+        assertThat(results).isEqualTo(expectedResults);
     }
 
     @Test
@@ -806,7 +808,7 @@ public class FiberTest implements Serializable {
         Fiber<Integer> f1 = new SerFiber1(scheduler, new SettableFutureFiberWriter(buf)).start();
         Fiber<Integer> f2 = Fiber.unparkSerialized(buf.get(), scheduler);
 
-        assertThat(f2.get(), is(55));
+        assertThat(f2.get()).isEqualTo(55);
     }
 
     static class SerFiber1 extends SerFiber<Integer> {
@@ -836,7 +838,7 @@ public class FiberTest implements Serializable {
         Fiber<Integer> f1 = new SerFiber2(scheduler, new SettableFutureFiberWriter(buf)).start();
         Fiber<Integer> f2 = Fiber.unparkSerialized(buf.get(), scheduler);
 
-        assertThat(f2.get(), is(55));
+        assertThat(f2.get()).isEqualTo(55);
     }
 
     static class SerFiber2 extends Fiber<Integer> {
@@ -871,7 +873,7 @@ public class FiberTest implements Serializable {
         Fiber<Integer> f1 = new SerFiber3(scheduler, new SettableFutureFiberWriter(buf), tl1, tl2).start();
         Fiber<Integer> f2 = Fiber.unparkSerialized(buf.get(), scheduler);
 
-        assertThat(f2.get(), is(55));
+        assertThat(f2.get()).isEqualTo(55);
     }
 
     static class SerFiber3 extends SerFiber<Integer> {
@@ -886,8 +888,8 @@ public class FiberTest implements Serializable {
 
         @Override
         public Integer run() throws SuspendExecution, InterruptedException {
-            assertThat(tl1.get(), is(nullValue()));
-            assertThat(tl2.get(), is("bar"));
+            assertThat(tl1.get()).isNull();
+            assertThat(tl2.get()).isEqualTo("bar");
 
             tl1.set("koko");
             tl2.set("bubu");
@@ -901,8 +903,8 @@ public class FiberTest implements Serializable {
                 }
             }
 
-            assertThat(tl1.get(), is("koko"));
-            assertThat(tl2.get(), is("bubu"));
+            assertThat(tl1.get()).isEqualTo("koko");
+            assertThat(tl2.get()).isEqualTo("bubu");
             return sum;
         }
     }
@@ -929,7 +931,7 @@ public class FiberTest implements Serializable {
         Fiber<Integer> f1 = new CustomSerFiber(scheduler, new SettableFutureCustomWriter(buf)).start();
         Fiber<Integer> f2 = Fiber.unparkSerialized(buf.get(), scheduler);
 
-        assertThat(f2.get(), is(55));
+        assertThat(f2.get()).isEqualTo(55);
     }
 
     static class CustomSerFiber extends Fiber<Integer> implements Serializable {

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/CatchTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/CatchTest.java
@@ -89,7 +89,7 @@ public class CatchTest {
         results.clear();
 
         try {
-            Fiber co = new Fiber((String) null, null, new Runnable1());
+            Fiber<?> co = new Fiber<>((String) null, null, new Runnable1());
             exec(co);
             results.add("B");
             exec(co);
@@ -145,7 +145,7 @@ public class CatchTest {
         results.clear();
 
         try {
-            Fiber co = new Fiber((String) null, null, new Callable1());
+            Fiber<?> co = new Fiber<>((String) null, null, new Callable1());
             exec(co);
             results.add("B");
             exec(co);
@@ -167,7 +167,7 @@ public class CatchTest {
     // See #211
     @Test
     public void testParkBeforeCatch() throws ExecutionException, InterruptedException {
-        new Fiber(new SuspendableRunnable() {
+        new Fiber<>(new SuspendableRunnable() {
             @Override
             public final void run() throws SuspendExecution, InterruptedException {
                 catchSuspendable();

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/FinallyTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/FinallyTest.java
@@ -67,7 +67,7 @@ public class FinallyTest implements SuspendableRunnable {
         results.clear();
         
         try {
-            Fiber co = new Fiber((String)null, null, this);
+            Fiber<?> co = new Fiber<>((String)null, null, this);
             exec(co);
             results.add("B");
             exec(co);

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/JavaPlatformTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/JavaPlatformTest.java
@@ -1,0 +1,85 @@
+package co.paralleluniverse.fibers.instrument;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+import static co.paralleluniverse.common.resource.ClassLoaderUtil.classToSlashed;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class JavaPlatformTest {
+    private static final String JRT_MODULES = "modules";
+    private static final String JRT_FS = "jrt:/";
+
+    @Test
+    public void testLoadingJavaPlatformClasses() throws IOException {
+        final FileSystem jrt = FileSystems.getFileSystem(URI.create(JRT_FS));
+        final Set<String> classNames = Files.walk(jrt.getPath(JRT_MODULES))
+            .filter(p -> p.getNameCount() > 2)
+            .filter(JavaPlatformTest::checkModuleExists)
+            .map(JavaPlatformTest::toFilePath)
+            .filter(p -> p.endsWith(".class"))
+            .map(p -> p.substring(0, p.length() - ".class".length()))
+            .filter(p -> !"module-info".equals(p))
+            .collect(Collectors.toUnmodifiableSet());
+
+        // Check that we correctly identify these classes as belonging to the JDK.
+        assertThat(classNames)
+            .allMatch(JavaPlatformTest::isJDKClass)
+            .isNotEmpty();
+
+        final ByteArrayOutputStream errors = new ByteArrayOutputStream();
+        final PrintStream oldStderr = System.err;
+        try (PrintStream stderr = new PrintStream(errors, true, UTF_8)) {
+            System.setErr(stderr);
+
+            // Check that Quasar can load each of these classes without error.
+            for (String className : classNames) {
+                try {
+                    Class.forName(className, false, ClassLoader.getSystemClassLoader());
+                } catch (ClassNotFoundException e) {
+                    e.printStackTrace(stderr);
+                    fail("Failed to load " + className + ": " + e.getMessage());
+                }
+            }
+        } finally {
+            System.setErr(oldStderr);
+
+            // Copy the output back to stderr for people to see.
+            System.err.write(errors.toByteArray());
+        }
+
+        final String[] lines = errors.toString(UTF_8).split(System.lineSeparator());
+        assertThat(lines).noneMatch(line -> line.startsWith("[quasar]"));
+    }
+
+    private static String toFilePath(Path p) {
+        final StringJoiner joiner = new StringJoiner(".");
+        for (int i = 2; i < p.getNameCount(); ++i) {
+            joiner.add(p.getName(i).toString());
+        }
+        return joiner.toString();
+    }
+
+    private static boolean checkModuleExists(Path p) {
+        final String moduleName = p.getName(1).toString();
+        return ModuleLayer.boot().findModule(moduleName).isPresent();
+    }
+
+    private static boolean isJDKClass(String className) {
+        // The Azul JDK contains some extra "platform" modules, so allow these.
+        return MethodDatabase.isJDK(classToSlashed(className)) || className.startsWith("com.azul.");
+    }
+}

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/SuspendableAnnotationTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/SuspendableAnnotationTest.java
@@ -64,7 +64,7 @@ public class SuspendableAnnotationTest {
     @Test
     public void testAnnotated() {
         try {
-            Fiber<?> co = new Fiber<>((String) null, null, (SuspendableCallable) null) {
+            Fiber<?> co = new Fiber<>((String) null, null, (SuspendableCallable<Object>) null) {
                 @Override
                 protected Object run() throws SuspendExecution, InterruptedException {
                     suspendableMethod();
@@ -87,7 +87,7 @@ public class SuspendableAnnotationTest {
         assumeFalse(SystemProperties.isEmptyOrTrue("co.paralleluniverse.fibers.verifyInstrumentation"));
 
         try {
-            Fiber<?> co = new Fiber<>((String) null, null, (SuspendableCallable) null) {
+            Fiber<?> co = new Fiber<>((String) null, null, (SuspendableCallable<Object>) null) {
                 @Override
                 protected Object run() throws SuspendExecution, InterruptedException {
                     nonsuspendableMethod();

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/io/FiberAsyncIOTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/io/FiberAsyncIOTest.java
@@ -31,9 +31,9 @@ import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import static java.nio.file.StandardOpenOption.*;
-import static org.hamcrest.CoreMatchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.After;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -86,12 +86,12 @@ public class FiberAsyncIOTest {
                         // long-typed reqeust/response
                         int n = ch.read(buf);
 
-                        assertThat(n, is(8)); // we assume the message is sent in a single packet
+                        assertThat(n).isEqualTo(8); // we assume the message is sent in a single packet
 
                         buf.flip();
                         long req = buf.getLong();
 
-                        assertThat(req, is(12345678L));
+                        assertThat(req).isEqualTo(12345678L);
 
                         buf.clear();
                         long res = 87654321L;
@@ -100,7 +100,7 @@ public class FiberAsyncIOTest {
 
                         n = ch.write(buf);
 
-                        assertThat(n, is(8));
+                        assertThat(n).isEqualTo(8);
 
                         // String reqeust/response
                         buf.clear();
@@ -109,7 +109,7 @@ public class FiberAsyncIOTest {
                         buf.flip();
                         String req2 = decoder.decode(buf).toString();
 
-                        assertThat(req2, is("my request"));
+                        assertThat(req2).isEqualTo("my request");
 
                         String res2 = "my response";
                         ch.write(encoder.encode(CharBuffer.wrap(res2)));
@@ -140,17 +140,17 @@ public class FiberAsyncIOTest {
 
                     int n = ch.write(buf);
 
-                    assertThat(n, is(8));
+                    assertThat(n).isEqualTo(8);
 
                     buf.clear();
                     n = ch.read(buf);
 
-                    assertThat(n, is(8)); // we assume the message is sent in a single packet
+                    assertThat(n).isEqualTo(8); // we assume the message is sent in a single packet
 
                     buf.flip();
                     long res = buf.getLong();
 
-                    assertThat(res, is(87654321L));
+                    assertThat(res).isEqualTo(87654321L);
 
                     // String reqeust/response
                     String req2 = "my request";
@@ -162,13 +162,13 @@ public class FiberAsyncIOTest {
                     buf.flip();
                     String res2 = decoder.decode(buf).toString();
 
-                    assertThat(res2, is("my response"));
+                    assertThat(res2).isEqualTo("my response");
 
                     // verify that the server has closed the socket
                     buf.clear();
                     n = ch.read(buf);
 
-                    assertThat(n, is(-1));
+                    assertThat(n).isEqualTo(-1);
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -196,7 +196,7 @@ public class FiberAsyncIOTest {
                     buf.flip();
                     String read = decoder.decode(buf).toString();
                     
-                    assertThat(read, equalTo(text));
+                    assertThat(read).isEqualTo(text);
                     
                     buf.clear();
                     
@@ -206,7 +206,7 @@ public class FiberAsyncIOTest {
                     buf.flip();
                     read = decoder.decode(buf).toString();
                     
-                    assertThat(read, equalTo(text.substring(5)));
+                    assertThat(read).isEqualTo(text.substring(5));
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/channels/ChannelTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/channels/ChannelTest.java
@@ -13,7 +13,6 @@
  */
 package co.paralleluniverse.strands.channels;
 
-import static co.paralleluniverse.common.test.Matchers.*;
 import co.paralleluniverse.common.test.TestUtil;
 import co.paralleluniverse.common.util.Debug;
 import co.paralleluniverse.fibers.Fiber;
@@ -25,17 +24,8 @@ import co.paralleluniverse.strands.SuspendableRunnable;
 import co.paralleluniverse.strands.channels.Channels.OverflowPolicy;
 import co.paralleluniverse.strands.queues.QueueCapacityExceededException;
 import com.google.common.collect.ImmutableSet;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.CoreMatchers.*;
 import org.junit.After;
-import org.junit.AfterClass;
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,6 +33,19 @@ import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import static co.paralleluniverse.common.test.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.*;
 
 /**
  *
@@ -114,7 +117,7 @@ public class ChannelTest {
             public void run() throws SuspendExecution, InterruptedException {
                 String m = ch.receive();
 
-                assertThat(m, equalTo("a message"));
+                assertThat(m).isEqualTo("a message");
             }
         }).start();
 
@@ -139,7 +142,7 @@ public class ChannelTest {
             public void run() throws SuspendExecution, InterruptedException {
                 String m = ch.receive();
 
-                assertThat(m, equalTo("a message"));
+                assertThat(m).isEqualTo("a message");
             }
         }).start();
 
@@ -164,7 +167,7 @@ public class ChannelTest {
 
         String m = ch.receive();
 
-        assertThat(m, equalTo("a message"));
+        assertThat(m).isEqualTo("a message");
 
         fib.join();
     }
@@ -189,7 +192,7 @@ public class ChannelTest {
 
         String m = ch.receive();
 
-        assertThat(m, equalTo("a message"));
+        assertThat(m).isEqualTo("a message");
 
         thread.join();
     }
@@ -219,9 +222,9 @@ public class ChannelTest {
         Thread.sleep(150);
 
         String m = ch.receive();
-        assertThat(m, equalTo("message 1"));
+        assertThat(m).isEqualTo("message 1");
         m = ch.receive(100, TimeUnit.MILLISECONDS);
-        assertThat(m, equalTo("message 2"));
+        assertThat(m).isEqualTo("message 2");
 
         thread.join();
     }
@@ -251,7 +254,7 @@ public class ChannelTest {
         Thread.sleep(250);
 
         String m = ch.receive();
-        assertThat(m, equalTo("message 1"));
+        assertThat(m).isEqualTo("message 1");
         m = ch.receive(100, TimeUnit.MILLISECONDS);
         assertNull(m);
 
@@ -269,7 +272,7 @@ public class ChannelTest {
             public void run() throws SuspendExecution, InterruptedException {
                 String m = ch.receive();
 
-                assertThat(m, equalTo("a message"));
+                assertThat(m).isEqualTo("a message");
             }
         }).start();
 
@@ -304,7 +307,7 @@ public class ChannelTest {
             public void run() throws SuspendExecution, InterruptedException {
                 String m = ch.receive();
 
-                assertThat(m, equalTo("a message"));
+                assertThat(m).isEqualTo("a message");
             }
         }).start();
 
@@ -347,7 +350,7 @@ public class ChannelTest {
 
         String m = ch.receive();
 
-        assertThat(m, equalTo("a message"));
+        assertThat(m).isEqualTo("a message");
 
         fib.join();
     }
@@ -442,7 +445,7 @@ public class ChannelTest {
         }).start();
 
         try {
-            assertThat(receiver.get(), is(10));
+            assertThat(receiver.get()).isEqualTo(10);
             sender.join();
         } catch (Throwable t) {
             Debug.dumpRecorder("channels.log");
@@ -472,7 +475,7 @@ public class ChannelTest {
             ch.send(i);
         ch.close();
 
-        assertThat(fib.get(), is(10));
+        assertThat(fib.get()).isEqualTo(10);
     }
 
     @Test
@@ -485,12 +488,12 @@ public class ChannelTest {
                 for (int i = 1; i <= 5; i++) {
                     Integer m = ch.receive();
 
-                    assertThat(m, equalTo(i));
+                    assertThat(m).isEqualTo(i);
                 }
 
                 Integer m = ch.receive();
 
-                assertThat(m, nullValue());
+                assertThat(m).isNull();
                 assertTrue(ch.isClosed());
             }
         }).start();
@@ -520,14 +523,14 @@ public class ChannelTest {
                 for (int i = 1; i <= 5; i++) {
                     Integer m = ch.receive();
 
-                    assertThat(m, equalTo(i));
+                    assertThat(m).isEqualTo(i);
                 }
 
                 try {
                     ch.receive();
                     fail();
                 } catch (ProducerException e) {
-                    assertThat(e.getCause().getMessage(), equalTo("foo"));
+                    assertThat(e.getCause().getMessage()).isEqualTo("foo");
                 }
                 assertTrue(ch.isClosed());
             }
@@ -558,12 +561,12 @@ public class ChannelTest {
                 for (int i = 1; i <= 5; i++) {
                     Integer m = ch.receive();
 
-                    assertThat(m, equalTo(i));
+                    assertThat(m).isEqualTo(i);
                 }
 
                 Integer m = ch.receive();
 
-                assertThat(m, nullValue());
+                assertThat(m).isNull();
                 assertTrue(ch.isClosed());
             }
         }).start();
@@ -594,14 +597,14 @@ public class ChannelTest {
                 for (int i = 1; i <= 5; i++) {
                     Integer m = ch.receive();
 
-                    assertThat(m, equalTo(i));
+                    assertThat(m).isEqualTo(i);
                 }
 
                 try {
                     Integer m = ch.receive();
                     fail("m = " + m);
                 } catch (ProducerException e) {
-                    assertThat(e.getCause().getMessage(), equalTo("foo"));
+                    assertThat(e.getCause().getMessage()).isEqualTo("foo");
                 }
                 assertTrue(ch.isClosed());
             }
@@ -682,7 +685,7 @@ public class ChannelTest {
                     for (int i = 1; i <= 5; i++) {
                         int m = ch.receiveInt();
 
-                        assertThat(m, is(i));
+                        assertThat(m).isEqualTo(i);
                     }
                 } catch (QueueChannel.EOFException e) {
                     fail();
@@ -726,7 +729,7 @@ public class ChannelTest {
                     for (int i = 1; i <= 5; i++) {
                         int m = ch.receiveInt();
 
-                        assertThat(m, is(i));
+                        assertThat(m).isEqualTo(i);
                     }
                 } catch (QueueChannel.EOFException e) {
                     fail();
@@ -736,7 +739,7 @@ public class ChannelTest {
                     int m = ch.receiveInt();
                     fail("m = " + m);
                 } catch (ProducerException e) {
-                    assertThat(e.getCause().getMessage(), equalTo("foo"));
+                    assertThat(e.getCause().getMessage()).isEqualTo("foo");
                 } catch (ReceivePort.EOFException e) {
                     fail();
                 }
@@ -775,24 +778,24 @@ public class ChannelTest {
         Fiber<?> f1 = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                assertThat(channel1.receive(), equalTo("hello"));
-                assertThat(channel1.receive(), equalTo("world!"));
+                assertThat(channel1.receive()).isEqualTo("hello");
+                assertThat(channel1.receive()).isEqualTo("world!");
             }
         }).start();
 
         Fiber<?> f2 = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                assertThat(channel2.receive(), equalTo("hello"));
-                assertThat(channel2.receive(), equalTo("world!"));
+                assertThat(channel2.receive()).isEqualTo("hello");
+                assertThat(channel2.receive()).isEqualTo("world!");
             }
         }).start();
 
         Fiber<?> f3 = new Fiber<>(scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                assertThat(channel3.receive(), equalTo("hello"));
-                assertThat(channel3.receive(), equalTo("world!"));
+                assertThat(channel3.receive()).isEqualTo("hello");
+                assertThat(channel3.receive()).isEqualTo("world!");
             }
         }).start();
 
@@ -820,8 +823,8 @@ public class ChannelTest {
                 String m1 = group.receive();
                 String m2 = channel2.receive();
 
-                assertThat(m1, equalTo("hello"));
-                assertThat(m2, equalTo("world!"));
+                assertThat(m1).isEqualTo("hello");
+                assertThat(m2).isEqualTo("world!");
             }
         }).start();
 
@@ -852,10 +855,10 @@ public class ChannelTest {
                 String m3 = group.receive(10, TimeUnit.MILLISECONDS);
                 String m4 = group.receive(200, TimeUnit.MILLISECONDS);
 
-                assertThat(m1, equalTo("hello"));
-                assertThat(m2, equalTo("world!"));
-                assertThat(m3, nullValue());
-                assertThat(m4, equalTo("foo"));
+                assertThat(m1).isEqualTo("hello");
+                assertThat(m2).isEqualTo("world!");
+                assertThat(m3).isNull();
+                assertThat(m4).isEqualTo("foo");
             }
         }).start();
 
@@ -896,17 +899,17 @@ public class ChannelTest {
                 final String m5 = group.receive(10, TimeUnit.MILLISECONDS);
                 final String m6 = group.receive(200, TimeUnit.MILLISECONDS);
 
-                assertThat(m1, equalTo("hello"));
-                assertThat(m2, equalTo("world!"));
-                assertThat(m3, nullValue());
-                assertThat(m4, equalTo("foo"));
-                assertThat(m5, nullValue());
-                assertThat(m6, equalTo("bar"));
+                assertThat(m1).isEqualTo("hello");
+                assertThat(m2).isEqualTo("world!");
+                assertThat(m3).isNull();
+                assertThat(m4).isEqualTo("foo");
+                assertThat(m5).isNull();
+                assertThat(m6).isEqualTo("bar");
 
                 sync.receive(); // 5
                 sync.receive(); // 6
                 final String m7 = group.receive();
-                assertThat(m7, equalTo("2-solo-sings"));
+                assertThat(m7).isEqualTo("2-solo-sings");
 
                 sync.receive(); // 7
                 sync.receive(); // 8
@@ -919,21 +922,21 @@ public class ChannelTest {
                 String m10 = group.receive();
                 while (m10 != null && m10.contains("leaks"))
                     m10 = group.receive();
-                assertThat(ImmutableSet.of(m8, m9, m10), equalTo(ImmutableSet.of("1-paused-by-2-solo-waits", "3-paused-by-2-solo-waits", "1-normal")));
+                assertThat(ImmutableSet.of(m8, m9, m10)).isEqualTo(ImmutableSet.of("1-paused-by-2-solo-waits", "3-paused-by-2-solo-waits", "1-normal"));
 
                 sync.receive(); // 9
                 sync.receive(); // 10
                 String m11 = group.receive();
                 while (m11 != null && m11.contains("leaks"))
                     m11 = group.receive();
-                assertThat(m11, equalTo("2-solo-sings-again"));
+                assertThat(m11).isEqualTo("2-solo-sings-again");
 
                 sync.receive(); // 11
                 sync.receive(); // 12
                 String m12 = group.receive();
                 while (m12 != null && m12.contains("leaks"))
                     m12 = group.receive();
-                assertThat(m12, nullValue());
+                assertThat(m12).isNull();
             }
         }).start();
 

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/channels/GeneralSelectorTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/channels/GeneralSelectorTest.java
@@ -21,21 +21,22 @@ import co.paralleluniverse.fibers.suspend.SuspendExecution;
 import co.paralleluniverse.strands.Strand;
 import co.paralleluniverse.strands.SuspendableRunnable;
 import co.paralleluniverse.strands.channels.Channels.OverflowPolicy;
-import static co.paralleluniverse.strands.channels.Selector.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import static org.hamcrest.CoreMatchers.*;
 import org.junit.After;
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static co.paralleluniverse.strands.channels.Selector.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assume.*;
 
 /**
  *
@@ -170,11 +171,11 @@ public class GeneralSelectorTest {
             //System.out.println("receiving");
             Integer x = in.receive();
             //System.out.println("receied " + x);
-            assertThat(x, is(i));
+            assertThat(x).isEqualTo(i);
         }
         out.close();
-        assertThat(in.receive(), nullValue());
-        assertThat(in.isClosed(), is(true));
+        assertThat(in.receive()).isNull();
+        assertThat(in.isClosed()).isTrue();
     }
 
     @Test
@@ -198,11 +199,11 @@ public class GeneralSelectorTest {
             ms[m] = true;
         }
         for (int i = 0; i < n; i++)
-            assertThat(ms[i], is(true));
+            assertThat(ms[i]).isTrue();
 
 
         out.close();
-        assertThat(in.receive(), nullValue());
-        assertThat(in.isClosed(), is(true));
+        assertThat(in.receive()).isNull();
+        assertThat(in.isClosed()).isTrue();
     }
 }

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/channels/TickerChannelTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/channels/TickerChannelTest.java
@@ -13,7 +13,6 @@
  */
 package co.paralleluniverse.strands.channels;
 
-import static co.paralleluniverse.common.test.Matchers.*;
 import co.paralleluniverse.common.test.TestUtil;
 import co.paralleluniverse.common.util.Debug;
 import co.paralleluniverse.fibers.Fiber;
@@ -22,13 +21,13 @@ import co.paralleluniverse.fibers.FiberScheduler;
 import co.paralleluniverse.fibers.suspend.SuspendExecution;
 import co.paralleluniverse.strands.Strand;
 import co.paralleluniverse.strands.SuspendableRunnable;
-import static org.hamcrest.CoreMatchers.*;
 import org.junit.After;
-import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
@@ -66,15 +65,15 @@ public class TickerChannelTest {
                 Integer m;
                 while ((m = ch.receive()) != null) {
                     //System.out.println(Strand.currentStrand() + ": " + m);
-                    long index = ((TickerChannelConsumer)ch).getLastIndexRead();
-                    assertThat("index", index, greaterThan(prevIndex));
-                    assertThat("message", m.intValue(), greaterThan(prev));
+                    long index = ((TickerChannelConsumer<?>)ch).getLastIndexRead();
+                    assertThat(index).describedAs("index").isGreaterThan(prevIndex);
+                    assertThat(m.intValue()).describedAs("message").isGreaterThan(prev);
 
                     prev = m;
                     prevIndex = index;
                 }
 
-                assertThat(ch.isClosed(), is(true));
+                assertThat(ch.isClosed()).isTrue();
             }
         };
 

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/channels/TransferSelectorTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/channels/TransferSelectorTest.java
@@ -23,10 +23,10 @@ import co.paralleluniverse.strands.Strand;
 import co.paralleluniverse.strands.SuspendableRunnable;
 import co.paralleluniverse.strands.channels.Channels.OverflowPolicy;
 import static co.paralleluniverse.strands.channels.Selector.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.concurrent.TimeUnit;
-import static org.hamcrest.CoreMatchers.*;
 import org.junit.After;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -78,7 +78,7 @@ public class TransferSelectorTest {
         final Channel<String> channel2 = newChannel();
         final Channel<String> channel3 = newChannel();
 
-        Fiber fib = new Fiber("fiber", scheduler, new SuspendableRunnable() {
+        Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 SelectAction<String> sa1 = select(
@@ -94,10 +94,10 @@ public class TransferSelectorTest {
                         receive(channel3));
                 String m2 = sa2.message();
 
-                assertThat(sa1.index(), is(0));
-                assertThat(m1, equalTo("hello"));
-                assertThat(sa2.index(), is(2));
-                assertThat(m2, equalTo("world!"));
+                assertThat(sa1.index()).isEqualTo(0);
+                assertThat(m1).isEqualTo("hello");
+                assertThat(sa2.index()).isEqualTo(2);
+                assertThat(m2).isEqualTo("world!");
             }
         }).start();
 
@@ -117,7 +117,7 @@ public class TransferSelectorTest {
         final Channel<String> channel2 = newChannel();
         final Channel<String> channel3 = newChannel();
 
-        Fiber fib = new Fiber("fiber", scheduler, new SuspendableRunnable() {
+        Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 Strand.sleep(200);
@@ -142,10 +142,10 @@ public class TransferSelectorTest {
                 String m1 = sa1.message();
                 String m2 = sa2.message();
 
-                assertThat(sa1.index(), is(0));
-                assertThat(m1, equalTo("hello"));
-                assertThat(sa2.index(), is(2));
-                assertThat(m2, equalTo("world!"));
+                assertThat(sa1.index()).isEqualTo(0);
+                assertThat(m1).isEqualTo("hello");
+                assertThat(sa2.index()).isEqualTo(2);
+                assertThat(m2).isEqualTo("world!");
             }
         }).start();
 
@@ -161,7 +161,7 @@ public class TransferSelectorTest {
         final Channel<String> channel2 = newChannel();
         final Channel<String> channel3 = newChannel();
 
-        Fiber fib = new Fiber("fiber", scheduler, new SuspendableRunnable() {
+        Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 SelectAction<String> sa1 = select(
@@ -177,9 +177,9 @@ public class TransferSelectorTest {
                         receive(channel3));
                 String m2 = sa2.message();
 
-                assertThat(sa1.index(), is(2));
-                assertThat(m1, nullValue());
-                assertThat(m2, nullValue());
+                assertThat(sa1.index()).isEqualTo(2);
+                assertThat(m1).isNull();
+                assertThat(m2).isNull();
             }
         }).start();
 
@@ -195,7 +195,7 @@ public class TransferSelectorTest {
         final Channel<String> channel2 = newChannel();
         final Channel<String> channel3 = newChannel();
 
-        Fiber fib = new Fiber("fiber", scheduler, new SuspendableRunnable() {
+        Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 Strand.sleep(200);
@@ -213,9 +213,9 @@ public class TransferSelectorTest {
                         receive(channel3));
                 String m2 = sa2.message();
 
-                assertThat(sa1.index(), is(2));
-                assertThat(m1, nullValue());
-                assertThat(m2, nullValue());
+                assertThat(sa1.index()).isEqualTo(2);
+                assertThat(m1).isNull();
+                assertThat(m2).isNull();
             }
         }).start();
 
@@ -230,7 +230,7 @@ public class TransferSelectorTest {
         final Channel<String> channel2 = newChannel();
         final Channel<String> channel3 = newChannel();
 
-        Fiber fib = new Fiber("fiber", scheduler, new SuspendableRunnable() {
+        Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 SelectAction<String> sa1 = select(1, TimeUnit.MILLISECONDS,
@@ -244,9 +244,9 @@ public class TransferSelectorTest {
                         receive(channel3));
                 String m2 = sa2.message();
 
-                assertThat(sa1, is(nullValue()));
-                assertThat(sa2.index(), is(0));
-                assertThat(m2, equalTo("hello"));
+                assertThat(sa1).isNull();
+                assertThat(sa2.index()).isEqualTo(0);
+                assertThat(m2).isEqualTo("hello");
             }
         }).start();
 
@@ -263,7 +263,7 @@ public class TransferSelectorTest {
         final Channel<String> channel2 = newChannel();
         final Channel<String> channel3 = newChannel();
 
-        Fiber fib = new Fiber("fiber", scheduler, new SuspendableRunnable() {
+        Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 SelectAction<String> sa1 = select(
@@ -279,9 +279,9 @@ public class TransferSelectorTest {
                         receive(TimeoutChannel.<String>timeout(300, TimeUnit.MILLISECONDS)));
                 String m2 = sa2.message();
 
-                assertThat(sa1.index(), is(3));
-                assertThat(sa2.index(), is(0));
-                assertThat(m2, equalTo("hello"));
+                assertThat(sa1.index()).isEqualTo(3);
+                assertThat(sa2.index()).isEqualTo(0);
+                assertThat(m2).isEqualTo("hello");
             }
         }).start();
 
@@ -298,7 +298,7 @@ public class TransferSelectorTest {
         final Channel<String> channel2 = newChannel();
         final Channel<String> channel3 = newChannel();
 
-        Fiber fib = new Fiber("fiber", scheduler, new SuspendableRunnable() {
+        Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 SelectAction<String> sa1 = select(
@@ -311,19 +311,19 @@ public class TransferSelectorTest {
                         send(channel2, "hi2"),
                         send(channel3, "hi3"));
 
-                assertThat(sa1.index(), is(1));
-                assertThat(sa2.index(), is(0));
+                assertThat(sa1.index()).isEqualTo(1);
+                assertThat(sa2.index()).isEqualTo(0);
             }
         }).start();
 
         Thread.sleep(200);
 
         String m1 = channel2.receive();
-        assertThat(m1, equalTo("hi2"));
+        assertThat(m1).isEqualTo("hi2");
 
         Thread.sleep(200);
         String m2 = channel1.receive();
-        assertThat(m2, equalTo("hi1"));
+        assertThat(m2).isEqualTo("hi1");
 
         fib.join();
     }
@@ -334,7 +334,7 @@ public class TransferSelectorTest {
         final Channel<String> channel2 = newChannel();
         final Channel<String> channel3 = newChannel();
 
-        Fiber fib = new Fiber("fiber", scheduler, new SuspendableRunnable() {
+        Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 Strand.sleep(200);
@@ -349,16 +349,16 @@ public class TransferSelectorTest {
                         send(channel2, "hi2"),
                         send(channel3, "hi3"));
 
-                assertThat(sa1.index(), is(1));
-                assertThat(sa2.index(), is(0));
+                assertThat(sa1.index()).isEqualTo(1);
+                assertThat(sa2.index()).isEqualTo(0);
             }
         }).start();
 
         String m1 = channel2.receive();
-        assertThat(m1, equalTo("hi2"));
+        assertThat(m1).isEqualTo("hi2");
 
         String m2 = channel1.receive();
-        assertThat(m2, equalTo("hi1"));
+        assertThat(m2).isEqualTo("hi1");
 
         fib.join();
     }
@@ -369,7 +369,7 @@ public class TransferSelectorTest {
         final Channel<String> channel2 = newChannel();
         final Channel<String> channel3 = newChannel();
 
-        Fiber fib = new Fiber("fiber", scheduler, new SuspendableRunnable() {
+        Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 SelectAction<String> sa1 = select(
@@ -382,8 +382,8 @@ public class TransferSelectorTest {
                         send(channel2, "hi2"),
                         send(channel3, "hi3"));
 
-                assertThat(sa1.index(), is(1));
-                assertThat(sa2.index(), is(1));
+                assertThat(sa1.index()).isEqualTo(1);
+                assertThat(sa2.index()).isEqualTo(1);
             }
         }).start();
 
@@ -400,7 +400,7 @@ public class TransferSelectorTest {
         final Channel<String> channel2 = newChannel();
         final Channel<String> channel3 = newChannel();
 
-        Fiber fib = new Fiber("fiber", scheduler, new SuspendableRunnable() {
+        Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 Strand.sleep(200);
@@ -415,8 +415,8 @@ public class TransferSelectorTest {
                         send(channel2, "hi2"),
                         send(channel3, "hi3"));
 
-                assertThat(sa1.index(), is(1));
-                assertThat(sa2.index(), is(1));
+                assertThat(sa1.index()).isEqualTo(1);
+                assertThat(sa2.index()).isEqualTo(1);
             }
         }).start();
 
@@ -432,7 +432,7 @@ public class TransferSelectorTest {
         final Channel<String> channel2 = newChannel();
         final Channel<String> channel3 = newChannel();
 
-        Fiber fib = new Fiber("fiber", scheduler, new SuspendableRunnable() {
+        Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 SelectAction<String> sa1 = select(1, TimeUnit.MILLISECONDS,
@@ -445,8 +445,8 @@ public class TransferSelectorTest {
                         send(channel2, "bye2"),
                         send(channel3, "bye3"));
 
-                assertThat(sa1, is(nullValue()));
-                assertThat(sa2.index(), is(2));
+                assertThat(sa1).isNull();
+                assertThat(sa2.index()).isEqualTo(2);
             }
         }).start();
 
@@ -454,7 +454,7 @@ public class TransferSelectorTest {
 
         String m1 = channel3.receive();
 
-        assertThat(m1, equalTo("bye3")); // the first send is cancelled
+        assertThat(m1).isEqualTo("bye3"); // the first send is cancelled
 
         fib.join();
     }
@@ -465,7 +465,7 @@ public class TransferSelectorTest {
         final Channel<String> channel2 = newChannel();
         final Channel<String> channel3 = newChannel();
 
-        Fiber fib = new Fiber("fiber", scheduler, new SuspendableRunnable() {
+        Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 SelectAction<String> sa1 = select(
@@ -480,8 +480,8 @@ public class TransferSelectorTest {
                         send(channel3, "bye3"),
                         receive(TimeoutChannel.<String>timeout(300, TimeUnit.MILLISECONDS)));
 
-                assertThat(sa1.index(), is(3));
-                assertThat(sa2.index(), is(2));
+                assertThat(sa1.index()).isEqualTo(3);
+                assertThat(sa2.index()).isEqualTo(2);
             }
         }).start();
 
@@ -489,7 +489,7 @@ public class TransferSelectorTest {
 
         String m1 = channel3.receive();
 
-        assertThat(m1, equalTo("bye3")); // the first send is cancelled
+        assertThat(m1).isEqualTo("bye3"); // the first send is cancelled
 
         fib.join();
     }

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/channels/TransformingChannelTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/channels/TransformingChannelTest.java
@@ -34,10 +34,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import static org.hamcrest.CoreMatchers.*;
 import org.junit.After;
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,6 +42,14 @@ import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.*;
 
 /**
  *
@@ -109,128 +114,128 @@ public class TransformingChannelTest {
     }
 
     @Test
-    public void transformingReceiveChannelIsEqualToChannel() throws Exception {
+    public void transformingReceiveChannelIsEqualToChannel() {
         final Channel<Integer> ch = newChannel();
-        ReceivePort<Integer> ch1 = Channels.filter((ReceivePort<Integer>) ch, new Predicate<Integer>() {
+        ReceivePort<Integer> ch1 = Channels.filter(ch, new Predicate<Integer>() {
             @Override
             public boolean apply(Integer input) {
                 return input % 2 == 0;
             }
         });
-        ReceivePort<Integer> ch2 = Channels.map((ReceivePort<Integer>) ch, new Function<Integer, Integer>() {
+        ReceivePort<Integer> ch2 = Channels.map(ch, new Function<Integer, Integer>() {
             @Override
             public Integer apply(Integer input) {
                 return input + 10;
             }
         });
-        ReceivePort<Integer> ch3 = Channels.flatMap((ReceivePort<Integer>) ch, new Function<Integer, ReceivePort<Integer>>() {
+        ReceivePort<Integer> ch3 = Channels.flatMap(ch, new Function<Integer, ReceivePort<Integer>>() {
             @Override
             public ReceivePort<Integer> apply(Integer input) {
                 return Channels.toReceivePort(Arrays.asList(new Integer[]{input * 10, input * 100, input * 1000}));
             }
         });
-        ReceivePort<Integer> ch4 = Channels.reduce((ReceivePort<Integer>) ch, new Function2<Integer, Integer, Integer>() {
+        ReceivePort<Integer> ch4 = Channels.reduce(ch, new Function2<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer accum, Integer input) {
                 return (accum += input);
             }
         }, 0);
-        ReceivePort<Integer> ch5 = Channels.take((ReceivePort<Integer>) ch, 1);
+        ReceivePort<Integer> ch5 = Channels.take(ch, 1);
 
-        assertTrue(ch1.equals(ch));
-        assertTrue(ch.equals(ch1));
-        assertTrue(ch2.equals(ch));
-        assertTrue(ch.equals(ch2));
-        assertTrue(ch3.equals(ch));
-        assertTrue(ch.equals(ch3));
-        assertTrue(ch4.equals(ch));
-        assertTrue(ch.equals(ch4));
-        assertTrue(ch5.equals(ch));
-        assertTrue(ch.equals(ch5));
+        assertEquals(ch1, ch);
+        assertEquals(ch, ch1);
+        assertEquals(ch2, ch);
+        assertEquals(ch, ch2);
+        assertEquals(ch3, ch);
+        assertEquals(ch, ch3);
+        assertEquals(ch4, ch);
+        assertEquals(ch, ch4);
+        assertEquals(ch5, ch);
+        assertEquals(ch, ch5);
 
-        assertTrue(ch1.equals(ch1));
-        assertTrue(ch1.equals(ch2));
-        assertTrue(ch1.equals(ch3));
-        assertTrue(ch1.equals(ch4));
-        assertTrue(ch1.equals(ch5));
-        assertTrue(ch2.equals(ch1));
-        assertTrue(ch2.equals(ch2));
-        assertTrue(ch2.equals(ch3));
-        assertTrue(ch2.equals(ch4));
-        assertTrue(ch2.equals(ch5));
-        assertTrue(ch3.equals(ch1));
-        assertTrue(ch3.equals(ch2));
-        assertTrue(ch3.equals(ch3));
-        assertTrue(ch3.equals(ch4));
-        assertTrue(ch3.equals(ch5));
-        assertTrue(ch4.equals(ch1));
-        assertTrue(ch4.equals(ch2));
-        assertTrue(ch4.equals(ch3));
-        assertTrue(ch4.equals(ch4));
-        assertTrue(ch4.equals(ch5));
-        assertTrue(ch5.equals(ch1));
-        assertTrue(ch5.equals(ch2));
-        assertTrue(ch5.equals(ch3));
-        assertTrue(ch5.equals(ch4));
-        assertTrue(ch5.equals(ch5));
+        assertEquals(ch1, ch1);
+        assertEquals(ch1, ch2);
+        assertEquals(ch1, ch3);
+        assertEquals(ch1, ch4);
+        assertEquals(ch1, ch5);
+        assertEquals(ch2, ch1);
+        assertEquals(ch2, ch2);
+        assertEquals(ch2, ch3);
+        assertEquals(ch2, ch4);
+        assertEquals(ch2, ch5);
+        assertEquals(ch3, ch1);
+        assertEquals(ch3, ch2);
+        assertEquals(ch3, ch3);
+        assertEquals(ch3, ch4);
+        assertEquals(ch3, ch5);
+        assertEquals(ch4, ch1);
+        assertEquals(ch4, ch2);
+        assertEquals(ch4, ch3);
+        assertEquals(ch4, ch4);
+        assertEquals(ch4, ch5);
+        assertEquals(ch5, ch1);
+        assertEquals(ch5, ch2);
+        assertEquals(ch5, ch3);
+        assertEquals(ch5, ch4);
+        assertEquals(ch5, ch5);
     }
 
     @Test
     public void transformingSendChannelIsEqualToChannel() throws Exception {
         final Channel<Integer> ch = newChannel();
-        SendPort<Integer> ch1 = Channels.filterSend((SendPort<Integer>) ch, new Predicate<Integer>() {
+        SendPort<Integer> ch1 = Channels.filterSend(ch, new Predicate<Integer>() {
             @Override
             public boolean apply(Integer input) {
                 return input % 2 == 0;
             }
         });
 
-        SendPort<Integer> ch2 = Channels.mapSend((SendPort<Integer>) ch, new Function<Integer, Integer>() {
+        SendPort<Integer> ch2 = Channels.mapSend(ch, new Function<Integer, Integer>() {
             @Override
             public Integer apply(Integer input) {
                 return input + 10;
             }
         });
 
-        SendPort<Integer> ch3 = Channels.flatMapSend(Channels.<Integer>newChannel(1), (SendPort<Integer>) ch, new Function<Integer, ReceivePort<Integer>>() {
+        SendPort<Integer> ch3 = Channels.flatMapSend(Channels.<Integer>newChannel(1), ch, new Function<Integer, ReceivePort<Integer>>() {
             @Override
             public ReceivePort<Integer> apply(Integer input) {
                 return Channels.toReceivePort(Arrays.asList(new Integer[]{input * 10, input * 100, input * 1000}));
             }
         });
 
-        SendPort<Integer> ch4 = Channels.reduceSend((SendPort<Integer>) ch, new Function2<Integer, Integer, Integer>() {
+        SendPort<Integer> ch4 = Channels.reduceSend(ch, new Function2<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer accum, Integer input) {
                 return (accum += input);
             }
         }, 0);
 
-        assertTrue(ch1.equals(ch));
-        assertTrue(ch.equals(ch1));
-        assertTrue(ch2.equals(ch));
-        assertTrue(ch.equals(ch2));
-        assertTrue(ch3.equals(ch));
-        assertTrue(ch.equals(ch3));
-        assertTrue(ch4.equals(ch));
-        assertTrue(ch.equals(ch4));
+        assertEquals(ch1, ch);
+        assertEquals(ch, ch1);
+        assertEquals(ch2, ch);
+        assertEquals(ch, ch2);
+        assertEquals(ch3, ch);
+        assertEquals(ch, ch3);
+        assertEquals(ch4, ch);
+        assertEquals(ch, ch4);
 
-        assertTrue(ch1.equals(ch1));
-        assertTrue(ch1.equals(ch2));
-        assertTrue(ch1.equals(ch3));
-        assertTrue(ch1.equals(ch4));
-        assertTrue(ch2.equals(ch1));
-        assertTrue(ch2.equals(ch2));
-        assertTrue(ch2.equals(ch3));
-        assertTrue(ch2.equals(ch4));
-        assertTrue(ch3.equals(ch1));
-        assertTrue(ch3.equals(ch2));
-        assertTrue(ch3.equals(ch3));
-        assertTrue(ch3.equals(ch4));
-        assertTrue(ch4.equals(ch1));
-        assertTrue(ch4.equals(ch2));
-        assertTrue(ch4.equals(ch3));
-        assertTrue(ch4.equals(ch4));
+        assertEquals(ch1, ch1);
+        assertEquals(ch1, ch2);
+        assertEquals(ch1, ch3);
+        assertEquals(ch1, ch4);
+        assertEquals(ch2, ch1);
+        assertEquals(ch2, ch2);
+        assertEquals(ch2, ch3);
+        assertEquals(ch2, ch4);
+        assertEquals(ch3, ch1);
+        assertEquals(ch3, ch2);
+        assertEquals(ch3, ch3);
+        assertEquals(ch3, ch4);
+        assertEquals(ch4, ch1);
+        assertEquals(ch4, ch2);
+        assertEquals(ch4, ch3);
+        assertEquals(ch4, ch4);
     }
 
     @Test
@@ -240,7 +245,7 @@ public class TransformingChannelTest {
         Fiber<?> fib1 = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                ReceivePort<Integer> ch1 = Channels.filter((ReceivePort<Integer>) ch, new Predicate<Integer>() {
+                ReceivePort<Integer> ch1 = Channels.filter(ch, new Predicate<Integer>() {
                     @Override
                     public boolean apply(Integer input) {
                         return input % 2 == 0;
@@ -251,9 +256,9 @@ public class TransformingChannelTest {
                 Integer m2 = ch1.receive();
                 Integer m3 = ch1.receive();
 
-                assertThat(m1, equalTo(2));
-                assertThat(m2, equalTo(4));
-                assertThat(m3, is(nullValue()));
+                assertThat(m1).isEqualTo(2);
+                assertThat(m2).isEqualTo(4);
+                assertThat(m3).isNull();
             }
         }).start();
 
@@ -282,7 +287,7 @@ public class TransformingChannelTest {
         Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                ReceivePort<Integer> ch1 = Channels.filter((ReceivePort<Integer>) ch, new Predicate<Integer>() {
+                ReceivePort<Integer> ch1 = Channels.filter(ch, new Predicate<Integer>() {
                     @Override
                     public boolean apply(Integer input) {
                         return input % 2 == 0;
@@ -293,9 +298,9 @@ public class TransformingChannelTest {
                 Integer m2 = ch1.receive();
                 Integer m3 = ch1.receive();
 
-                assertThat(m1, equalTo(2));
-                assertThat(m2, equalTo(4));
-                assertThat(m3, is(nullValue()));
+                assertThat(m1).isEqualTo(2);
+                assertThat(m2).isEqualTo(4);
+                assertThat(m3).isNull();
             }
         }).start();
 
@@ -331,7 +336,7 @@ public class TransformingChannelTest {
             }
         }).start();
 
-        ReceivePort<Integer> ch1 = Channels.filter((ReceivePort<Integer>) ch, new Predicate<Integer>() {
+        ReceivePort<Integer> ch1 = Channels.filter(ch, new Predicate<Integer>() {
             @Override
             public boolean apply(Integer input) {
                 return input % 2 == 0;
@@ -342,9 +347,9 @@ public class TransformingChannelTest {
         Integer m2 = ch1.receive();
         Integer m3 = ch1.receive();
 
-        assertThat(m1, equalTo(2));
-        assertThat(m2, equalTo(4));
-        assertThat(m3, is(nullValue()));
+        assertThat(m1).isEqualTo(2);
+        assertThat(m2).isEqualTo(4);
+        assertThat(m3).isNull();
 
         fib.join();
     }
@@ -358,7 +363,7 @@ public class TransformingChannelTest {
         final Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                final ReceivePort<Integer> ch1 = Channels.filter((ReceivePort<Integer>) ch, new Predicate<Integer>() {
+                final ReceivePort<Integer> ch1 = Channels.filter(ch, new Predicate<Integer>() {
                     @Override
                     public boolean apply(Integer input) {
                         return input % 2 == 0;
@@ -373,10 +378,10 @@ public class TransformingChannelTest {
                 final Integer m2 = ch1.receive(190, TimeUnit.MILLISECONDS);
                 final Integer m3 = ch1.receive(30, TimeUnit.MILLISECONDS);
 
-                assertThat(m1, equalTo(2));
-                assertThat(m0, is(nullValue()));
-                assertThat(m2, equalTo(4));
-                assertThat(m3, is(nullValue()));
+                assertThat(m1).isEqualTo(2);
+                assertThat(m0).isNull();
+                assertThat(m2).isEqualTo(4);
+                assertThat(m3).isNull();
             }
         }).start();
 
@@ -407,16 +412,16 @@ public class TransformingChannelTest {
                 Integer m2 = ch.receive();
                 Integer m3 = ch.receive();
 
-                assertThat(m1, equalTo(2));
-                assertThat(m2, equalTo(4));
-                assertThat(m3, is(nullValue()));
+                assertThat(m1).isEqualTo(2);
+                assertThat(m2).isEqualTo(4);
+                assertThat(m3).isNull();
             }
         }).start();
 
         Fiber<?> fib2 = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                SendPort<Integer> ch1 = Channels.filterSend((SendPort<Integer>) ch, new Predicate<Integer>() {
+                SendPort<Integer> ch1 = Channels.filterSend(ch, new Predicate<Integer>() {
                     @Override
                     public boolean apply(Integer input) {
                         return input % 2 == 0;
@@ -449,13 +454,13 @@ public class TransformingChannelTest {
                 Integer m2 = ch.receive();
                 Integer m3 = ch.receive();
 
-                assertThat(m1, equalTo(2));
-                assertThat(m2, equalTo(4));
-                assertThat(m3, is(nullValue()));
+                assertThat(m1).isEqualTo(2);
+                assertThat(m2).isEqualTo(4);
+                assertThat(m3).isNull();
             }
         }).start();
 
-        SendPort<Integer> ch1 = Channels.filterSend((SendPort<Integer>) ch, new Predicate<Integer>() {
+        SendPort<Integer> ch1 = Channels.filterSend(ch, new Predicate<Integer>() {
             @Override
             public boolean apply(Integer input) {
                 return input % 2 == 0;
@@ -483,7 +488,7 @@ public class TransformingChannelTest {
             public void run() throws SuspendExecution, InterruptedException {
                 Fiber.sleep(100);
 
-                SendPort<Integer> ch1 = Channels.filterSend((SendPort<Integer>) ch, new Predicate<Integer>() {
+                SendPort<Integer> ch1 = Channels.filterSend(ch, new Predicate<Integer>() {
                     @Override
                     public boolean apply(Integer input) {
                         return input % 2 == 0;
@@ -505,9 +510,9 @@ public class TransformingChannelTest {
         Integer m2 = ch.receive();
         Integer m3 = ch.receive();
 
-        assertThat(m1, equalTo(2));
-        assertThat(m2, equalTo(4));
-        assertThat(m3, is(nullValue()));
+        assertThat(m1).isEqualTo(2);
+        assertThat(m2).isEqualTo(4);
+        assertThat(m3).isNull();
 
         fib.join();
     }
@@ -529,14 +534,14 @@ public class TransformingChannelTest {
                 final Integer m2 = ch.receive(190, TimeUnit.MILLISECONDS);
                 final Integer m3 = ch.receive(30, TimeUnit.MILLISECONDS);
 
-                assertThat(m1, equalTo(2));
-                assertThat(m0, is(nullValue()));
-                assertThat(m2, equalTo(4));
-                assertThat(m3, is(nullValue()));
+                assertThat(m1).isEqualTo(2);
+                assertThat(m0).isNull();
+                assertThat(m2).isEqualTo(4);
+                assertThat(m3).isNull();
             }
         }).start();
 
-        SendPort<Integer> ch1 = Channels.filterSend((SendPort<Integer>) ch, new Predicate<Integer>() {
+        SendPort<Integer> ch1 = Channels.filterSend(ch, new Predicate<Integer>() {
             @Override
             public boolean apply(Integer input) {
                 return input % 2 == 0;
@@ -566,7 +571,7 @@ public class TransformingChannelTest {
         Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                ReceivePort<Integer> ch1 = Channels.map((ReceivePort<Integer>) ch, new Function<Integer, Integer>() {
+                ReceivePort<Integer> ch1 = Channels.map(ch, new Function<Integer, Integer>() {
                     @Override
                     public Integer apply(Integer input) {
                         return input + 10;
@@ -580,12 +585,12 @@ public class TransformingChannelTest {
                 Integer m5 = ch1.receive();
                 Integer m6 = ch1.receive();
 
-                assertThat(m1, equalTo(11));
-                assertThat(m2, equalTo(12));
-                assertThat(m3, equalTo(13));
-                assertThat(m4, equalTo(14));
-                assertThat(m5, equalTo(15));
-                assertThat(m6, is(nullValue()));
+                assertThat(m1).isEqualTo(11);
+                assertThat(m2).isEqualTo(12);
+                assertThat(m3).isEqualTo(13);
+                assertThat(m4).isEqualTo(14);
+                assertThat(m5).isEqualTo(15);
+                assertThat(m6).isNull();
             }
         }).start();
 
@@ -615,16 +620,16 @@ public class TransformingChannelTest {
                 Integer m5 = ch.receive();
                 Integer m6 = ch.receive();
 
-                assertThat(m1, equalTo(11));
-                assertThat(m2, equalTo(12));
-                assertThat(m3, equalTo(13));
-                assertThat(m4, equalTo(14));
-                assertThat(m5, equalTo(15));
-                assertThat(m6, is(nullValue()));
+                assertThat(m1).isEqualTo(11);
+                assertThat(m2).isEqualTo(12);
+                assertThat(m3).isEqualTo(13);
+                assertThat(m4).isEqualTo(14);
+                assertThat(m5).isEqualTo(15);
+                assertThat(m6).isNull();
             }
         }).start();
 
-        SendPort<Integer> ch1 = Channels.mapSend((SendPort<Integer>) ch, new Function<Integer, Integer>() {
+        SendPort<Integer> ch1 = Channels.mapSend(ch, new Function<Integer, Integer>() {
             @Override
             public Integer apply(Integer input) {
                 return input + 10;
@@ -650,7 +655,7 @@ public class TransformingChannelTest {
         Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                final ReceivePort<Integer> ch1 = Channels.reduce((ReceivePort<Integer>) ch, new Function2<Integer, Integer, Integer>() {
+                final ReceivePort<Integer> ch1 = Channels.reduce(ch, new Function2<Integer, Integer, Integer>() {
                     @Override
                     public Integer apply(Integer accum, Integer input) {
                         return accum + input;
@@ -664,12 +669,12 @@ public class TransformingChannelTest {
                 final Integer m5 = ch1.receive();
                 final Integer m6 = ch1.receive();
 
-                assertThat(m1, equalTo(1));
-                assertThat(m2, equalTo(3));
-                assertThat(m3, equalTo(6));
-                assertThat(m4, equalTo(10));
-                assertThat(m5, equalTo(15));
-                assertThat(m6, is(nullValue()));
+                assertThat(m1).isEqualTo(1);
+                assertThat(m2).isEqualTo(3);
+                assertThat(m3).isEqualTo(6);
+                assertThat(m4).isEqualTo(10);
+                assertThat(m5).isEqualTo(15);
+                assertThat(m6).isNull();
             }
         }).start();
 
@@ -692,7 +697,7 @@ public class TransformingChannelTest {
         Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                final ReceivePort<Integer> ch1 = Channels.reduce((ReceivePort<Integer>) ch, new Function2<Integer, Integer, Integer>() {
+                final ReceivePort<Integer> ch1 = Channels.reduce(ch, new Function2<Integer, Integer, Integer>() {
                     @Override
                     public Integer apply(Integer accum, Integer input) {
                         return accum + input;
@@ -702,7 +707,7 @@ public class TransformingChannelTest {
                 final Integer m1 = ch1.receive();
                 final Integer m2 = ch1.receive();
 
-                assertThat(m1, equalTo(0));
+                assertThat(m1).isEqualTo(0);
                 assertNull(m2);
             }
         }).start();
@@ -721,20 +726,20 @@ public class TransformingChannelTest {
         final Channel<Object> takeSourceCh = newChannel();
 
         // Test 2 fibers failing immediately on take 0 of 1
-        final ReceivePort<Object> take0RP = Channels.take((ReceivePort<Object>) takeSourceCh, 0);
+        final ReceivePort<Object> take0RP = Channels.take(takeSourceCh, 0);
         final SuspendableRunnable take0SR = new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                assertThat(take0RP.receive(), is(nullValue()));
-                assertThat(take0RP.tryReceive(), is(nullValue()));
+                assertThat(take0RP.receive()).isNull();
+                assertThat(take0RP.tryReceive()).isNull();
                 long start = System.nanoTime();
-                assertThat(take0RP.receive(10, TimeUnit.SECONDS), is(nullValue()));
+                assertThat(take0RP.receive(10, TimeUnit.SECONDS)).isNull();
                 long end = System.nanoTime();
-                assertThat(end - start, lessThan(new Long(5 * 1000 * 1000 * 1000))); // Should be immediate
+                assertThat(end - start).isLessThan(5 * 1000 * 1000 * 1000L); // Should be immediate
                 start = System.nanoTime();
-                assertThat(take0RP.receive(new Timeout(10, TimeUnit.SECONDS)), is(nullValue()));
+                assertThat(take0RP.receive(new Timeout(10, TimeUnit.SECONDS))).isNull();
                 end = System.nanoTime();
-                assertThat(end - start, lessThan(new Long(5 * 1000 * 1000 * 1000))); // Should be immediate
+                assertThat(end - start).isLessThan(5 * 1000 * 1000 * 1000L); // Should be immediate
             }
         };
         final Fiber<?> take0Of1Fiber1 = new Fiber<>("take-0-of-1_fiber1", scheduler, take0SR).start();
@@ -742,17 +747,17 @@ public class TransformingChannelTest {
         takeSourceCh.send(new Object());
         take0Of1Fiber1.join();
         take0Of1Fiber2.join();
-        assertThat(takeSourceCh.receive(), is(notNullValue())); // 1 left in source, check and cleanup
+        assertThat(takeSourceCh.receive()).isNotNull(); // 1 left in source, check and cleanup
 
         // Test tryReceive failing immediately when fiber blocked in receive on take 1 of 2
-        final ReceivePort<Object> take1Of2RP = Channels.take((ReceivePort<Object>) takeSourceCh, 1);
+        final ReceivePort<Object> take1Of2RP = Channels.take(takeSourceCh, 1);
         final Fiber<?> timeoutSucceedingTake1Of2 = new Fiber<>("take-1-of-2_timeout_success", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 final long start = System.nanoTime();
-                assertThat(take1Of2RP.receive(1, TimeUnit.SECONDS), is(notNullValue()));
+                assertThat(take1Of2RP.receive(1, TimeUnit.SECONDS)).isNotNull();
                 final long end = System.nanoTime();
-                assertThat(end - start, lessThan(new Long(500 * 1000 * 1000)));
+                assertThat(end - start).isLessThan(500 * 1000 * 1000L);
             }
         }).start();
         Thread.sleep(100); // Let the fiber blocks in receive before starting the try
@@ -760,9 +765,9 @@ public class TransformingChannelTest {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 final long start = System.nanoTime();
-                assertThat(take1Of2RP.tryReceive(), is(nullValue()));
+                assertThat(take1Of2RP.tryReceive()).isNull();
                 final long end = System.nanoTime();
-                assertThat(end - start, lessThan(new Long(500 * 1000 * 1000))); // Should be immediate
+                assertThat(end - start).isLessThan(500 * 1000 * 1000L); // Should be immediate
             }
         }).start();
         Thread.sleep(100);
@@ -771,7 +776,7 @@ public class TransformingChannelTest {
         takeSourceCh.send(new Object());
         timeoutSucceedingTake1Of2.join();
         tryFailingTake1Of2.join();
-        assertThat(takeSourceCh.receive(), is(notNullValue())); // 1 left in source, check and cleanup
+        assertThat(takeSourceCh.receive()).isNotNull(); // 1 left in source, check and cleanup
 
         // Comprehensive take + contention test:
         //
@@ -785,7 +790,7 @@ public class TransformingChannelTest {
         // - 4th fiber taking over, receiving with 1s timeout => success
         // - 5th fiber asking untimed receive, waiting in monitor, will bail out because of take threshold
 
-        final ReceivePort<Object> take2Of3RPComprehensive = Channels.take((ReceivePort<Object>) takeSourceCh, 2);
+        final ReceivePort<Object> take2Of3RPComprehensive = Channels.take(takeSourceCh, 2);
         final Function2<Long, Integer, Fiber<?>> take1SRFun = new Function2<Long, Integer, Fiber<?>>() {
             @Override
             public Fiber<?> apply(final Long timeoutMS, final Integer position) {
@@ -800,24 +805,24 @@ public class TransformingChannelTest {
                         final long end = System.nanoTime();
                         switch (position) {
                             case 1:
-                                assertThat(res, is(notNullValue()));
-                                assertThat(end - start, lessThan(new Long(300 * 1000 * 1000)));
+                                assertThat(res).isNotNull();
+                                assertThat(end - start).isLessThan(300 * 1000 * 1000L);
                                 break;
                             case 2:
-                                assertThat(res, is(nullValue()));
-                                assertThat(end - start, greaterThan(new Long(300 * 1000 * 1000)));
+                                assertThat(res).isNull();
+                                assertThat(end - start).isGreaterThan(300 * 1000 * 1000L);
                                 break;
                             case 3:
-                                assertThat(res, is(nullValue()));
-                                assertThat(end - start, greaterThan(new Long(200 * 1000 * 1000)));
+                                assertThat(res).isNull();
+                                assertThat(end - start).isGreaterThan(200 * 1000 * 1000L);
                                 break;
                             case 4:
-                                assertThat(res, is(notNullValue()));
-                                assertThat(end - start, lessThan(new Long(1000 * 1000 * 1000)));
+                                assertThat(res).isNotNull();
+                                assertThat(end - start).isLessThan(1000 * 1000 * 1000L);
                                 break;
                             case 5:
-                                assertThat(res, is(nullValue()));
-                                assertThat(end - start, lessThan(new Long(1000 * 1000 * 1000))); // Should be almost instantaneous
+                                assertThat(res).isNull();
+                                assertThat(end - start).isLessThan(1000 * 1000 * 1000L); // Should be almost instantaneous
                                 break;
                             default:
                                 fail();
@@ -829,41 +834,41 @@ public class TransformingChannelTest {
         };
         final Fiber<?>[] competing = new Fiber[5];
         // First front fiber winning first message
-        competing[0] = take1SRFun.apply(300l, 1).start();
+        competing[0] = take1SRFun.apply(300L, 1).start();
         // Make 1 message available immediately for the first front fiber to consume
         takeSourceCh.send(new Object());
         Thread.sleep(100);
         // Second front fiber losing (waiting too little for second message)
-        competing[1] = take1SRFun.apply(300l, 2).start();
+        competing[1] = take1SRFun.apply(300L, 2).start();
         Thread.sleep(100);
         // First waiter, will fail (not waiting enough)
-        competing[2] = take1SRFun.apply(200l, 3).start();
+        competing[2] = take1SRFun.apply(200L, 3).start();
         Thread.sleep(300); // First waiter takeover
         // Second waiter, will win second message (waiting enough)
-        competing[3] = take1SRFun.apply(1000l, 4).start();
+        competing[3] = take1SRFun.apply(1000L, 4).start();
         Thread.sleep(300); // Second waiter takeover
         // Third waiter, will try after take threshold and will bail out
-        competing[4] = take1SRFun.apply(-1l, 5).start();
+        competing[4] = take1SRFun.apply(-1L, 5).start();
         // Make 2 more messages available
         takeSourceCh.send(new Object());
         takeSourceCh.send(new Object());
         // Wait fibers to finsh
         for (final Fiber<?> f : competing)
             f.join();
-        assertThat(takeSourceCh.receive(), is(notNullValue())); // 1 left in source, check and cleanup
+        assertThat(takeSourceCh.receive()).isNotNull(); // 1 left in source, check and cleanup
 
         // Explicit (and uncoupled from source) closing of TakeSP
-        final ReceivePort<Object> take1Of0ExplicitClose = Channels.take((ReceivePort<Object>) takeSourceCh, 1);
+        final ReceivePort<Object> take1Of0ExplicitClose = Channels.take(takeSourceCh, 1);
         final SuspendableRunnable explicitCloseSR = new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
                 final long start = System.nanoTime();
                 final Object ret = take1Of0ExplicitClose.receive();
                 final long end = System.nanoTime();
-                assertThat(ret, is(nullValue()));
+                assertThat(ret).isNull();
                 assertTrue(take1Of0ExplicitClose.isClosed());
                 assertFalse(takeSourceCh.isClosed());
-                assertThat(end - start, lessThan(new Long(500 * 1000 * 1000)));
+                assertThat(end - start).isLessThan(500 * 1000 * 1000L);
             }
         };
         final Fiber<?> explicitCloseF1 = new Fiber<>("take-explicit-close-1", scheduler, explicitCloseSR);
@@ -886,16 +891,16 @@ public class TransformingChannelTest {
                 Integer m5 = ch.receive();
                 Integer m6 = ch.receive();
 
-                assertThat(m1, equalTo(1));
-                assertThat(m2, equalTo(3));
-                assertThat(m3, equalTo(6));
-                assertThat(m4, equalTo(10));
-                assertThat(m5, equalTo(15));
-                assertThat(m6, is(nullValue()));
+                assertThat(m1).isEqualTo(1);
+                assertThat(m2).isEqualTo(3);
+                assertThat(m3).isEqualTo(6);
+                assertThat(m4).isEqualTo(10);
+                assertThat(m5).isEqualTo(15);
+                assertThat(m6).isNull();
             }
         }).start();
 
-        final SendPort<Integer> ch1 = Channels.reduceSend((SendPort<Integer>) ch, new Function2<Integer, Integer, Integer>() {
+        final SendPort<Integer> ch1 = Channels.reduceSend(ch, new Function2<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer accum, Integer input) {
                 return accum + input;
@@ -924,12 +929,12 @@ public class TransformingChannelTest {
                 Integer m1 = ch.receive();
                 Integer m2 = ch.receive();
 
-                assertThat(m1, equalTo(0));
+                assertThat(m1).isEqualTo(0);
                 assertNull(m2);
             }
         }).start();
 
-        final SendPort<Integer> ch1 = Channels.reduceSend((SendPort<Integer>) ch, new Function2<Integer, Integer, Integer>() {
+        final SendPort<Integer> ch1 = Channels.reduceSend(ch, new Function2<Integer, Integer, Integer>() {
             @Override
             public Integer apply(Integer accum, Integer input) {
                 return accum + input;
@@ -962,10 +967,10 @@ public class TransformingChannelTest {
                 String m3 = ch.receive();
                 String m4 = ch.receive();
 
-                assertThat(m1, equalTo("a1"));
-                assertThat(m2, equalTo("b2"));
-                assertThat(m3, equalTo("c3"));
-                assertThat(m4, is(nullValue()));
+                assertThat(m1).isEqualTo("a1");
+                assertThat(m2).isEqualTo("b2");
+                assertThat(m3).isEqualTo("c3");
+                assertThat(m4).isNull();
             }
         }).start();
 
@@ -1011,11 +1016,11 @@ public class TransformingChannelTest {
                 sync.receive(); // 3
                 final String m4 = ch.receive(30, TimeUnit.MILLISECONDS);
 
-                assertThat(m1, equalTo("a1"));
-                assertThat(m0, is(nullValue()));
-                assertThat(m2, equalTo("b2"));
-                assertThat(m3, equalTo("c3"));
-                assertThat(m4, is(nullValue()));
+                assertThat(m1).isEqualTo("a1");
+                assertThat(m0).isNull();
+                assertThat(m2).isEqualTo("b2");
+                assertThat(m3).isEqualTo("c3");
+                assertThat(m4).isNull();
             }
         }).start();
 
@@ -1054,22 +1059,22 @@ public class TransformingChannelTest {
                         if (x == 3)
                             return null;
                         if (x % 2 == 0)
-                            return Channels.toReceivePort(Arrays.asList(new Integer[]{x * 10, x * 100, x * 1000}));
+                            return Channels.toReceivePort(Arrays.asList(x * 10, x * 100, x * 1000));
                         else
                             return Channels.singletonReceivePort(x);
                     }
                 });
 
-                assertThat(ch.receive(), is(1));
-                assertThat(ch.receive(), is(20));
-                assertThat(ch.receive(), is(200));
-                assertThat(ch.receive(), is(2000));
-                assertThat(ch.receive(), is(40));
-                assertThat(ch.receive(), is(400));
-                assertThat(ch.receive(), is(4000));
-                assertThat(ch.receive(), is(5));
-                assertThat(ch.receive(), is(nullValue()));
-                assertThat(ch.isClosed(), is(true));
+                assertThat(ch.receive()).isEqualTo(1);
+                assertThat(ch.receive()).isEqualTo(20);
+                assertThat(ch.receive()).isEqualTo(200);
+                assertThat(ch.receive()).isEqualTo(2000);
+                assertThat(ch.receive()).isEqualTo(40);
+                assertThat(ch.receive()).isEqualTo(400);
+                assertThat(ch.receive()).isEqualTo(4000);
+                assertThat(ch.receive()).isEqualTo(5);
+                assertThat(ch.receive()).isNull();
+                assertThat(ch.isClosed()).isTrue();
             }
         }).start();
 
@@ -1098,33 +1103,33 @@ public class TransformingChannelTest {
                         if (x == 3)
                             return null; // Discard
                         if (x % 2 == 0)
-                            return Channels.toReceivePort(Arrays.asList(new Integer[]{x * 10, x * 100, x * 1000}));
+                            return Channels.toReceivePort(Arrays.asList(x * 10, x * 100, x * 1000));
                         else
                             return Channels.singletonReceivePort(x);
                     }
                 });
 
                 sync.receive(); // 0
-                assertThat(ch.receive(200, TimeUnit.MILLISECONDS), is(1));
+                assertThat(ch.receive(200, TimeUnit.MILLISECONDS)).isEqualTo(1);
 
                 sync.receive(); // 1
-                assertThat(ch.receive(10, TimeUnit.MILLISECONDS), is(nullValue()));
-                assertThat(ch.receive(190, TimeUnit.MILLISECONDS), is(20));
-                assertThat(ch.receive(10, TimeUnit.MILLISECONDS), is(200));
-                assertThat(ch.receive(10, TimeUnit.MILLISECONDS), is(2000));
+                assertThat(ch.receive(10, TimeUnit.MILLISECONDS)).isNull();
+                assertThat(ch.receive(190, TimeUnit.MILLISECONDS)).isEqualTo(20);
+                assertThat(ch.receive(10, TimeUnit.MILLISECONDS)).isEqualTo(200);
+                assertThat(ch.receive(10, TimeUnit.MILLISECONDS)).isEqualTo(2000);
 
                 sync.receive(); // 2
-                assertThat(ch.receive(200, TimeUnit.MILLISECONDS), is(40));
-                assertThat(ch.receive(10, TimeUnit.MILLISECONDS), is(400));
-                assertThat(ch.receive(10, TimeUnit.MILLISECONDS), is(4000));
+                assertThat(ch.receive(200, TimeUnit.MILLISECONDS)).isEqualTo(40);
+                assertThat(ch.receive(10, TimeUnit.MILLISECONDS)).isEqualTo(400);
+                assertThat(ch.receive(10, TimeUnit.MILLISECONDS)).isEqualTo(4000);
 
                 sync.receive(); // 3
-                assertThat(ch.receive(10, TimeUnit.MILLISECONDS), is(nullValue()));
-                assertThat(ch.receive(190, TimeUnit.MILLISECONDS), is(5));
+                assertThat(ch.receive(10, TimeUnit.MILLISECONDS)).isNull();
+                assertThat(ch.receive(190, TimeUnit.MILLISECONDS)).isEqualTo(5);
 
                 sync.receive(); // 4
-                assertThat(ch.receive(30, TimeUnit.MILLISECONDS), is(nullValue()));
-                assertThat(ch.isClosed(), is(true));
+                assertThat(ch.receive(30, TimeUnit.MILLISECONDS)).isNull();
+                assertThat(ch.isClosed()).isTrue();
             }
         }).start();
 
@@ -1172,10 +1177,10 @@ public class TransformingChannelTest {
         Fiber<?> fib1 = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                assertThat(out.receive(), equalTo(20));
-                assertThat(out.receive(), equalTo(40));
-                assertThat(out.receive(), equalTo(1234));
-                assertThat(out.receive(), is(nullValue()));
+                assertThat(out.receive()).isEqualTo(20);
+                assertThat(out.receive()).isEqualTo(40);
+                assertThat(out.receive()).isEqualTo(1234);
+                assertThat(out.receive()).isNull();
             }
         }).start();
 
@@ -1204,16 +1209,16 @@ public class TransformingChannelTest {
         Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                assertThat(ch.receive(), is(1));
-                assertThat(ch.receive(), is(20));
-                assertThat(ch.receive(), is(200));
-                assertThat(ch.receive(), is(2000));
-                assertThat(ch.receive(), is(40));
-                assertThat(ch.receive(), is(400));
-                assertThat(ch.receive(), is(4000));
-                assertThat(ch.receive(), is(5));
-                assertThat(ch.receive(), is(nullValue()));
-                assertThat(ch.isClosed(), is(true));
+                assertThat(ch.receive()).isEqualTo(1);
+                assertThat(ch.receive()).isEqualTo(20);
+                assertThat(ch.receive()).isEqualTo(200);
+                assertThat(ch.receive()).isEqualTo(2000);
+                assertThat(ch.receive()).isEqualTo(40);
+                assertThat(ch.receive()).isEqualTo(400);
+                assertThat(ch.receive()).isEqualTo(4000);
+                assertThat(ch.receive()).isEqualTo(5);
+                assertThat(ch.receive()).isNull();
+                assertThat(ch.isClosed()).isTrue();
             }
         }).start();
 
@@ -1223,7 +1228,7 @@ public class TransformingChannelTest {
                 if (x == 3)
                     return null;
                 if (x % 2 == 0)
-                    return Channels.toReceivePort(Arrays.asList(new Integer[]{x * 10, x * 100, x * 1000}));
+                    return Channels.toReceivePort(Arrays.asList(x * 10, x * 100, x * 1000));
                 else
                     return Channels.singletonReceivePort(x);
             }
@@ -1245,18 +1250,18 @@ public class TransformingChannelTest {
         Fiber<?> fib = new Fiber<>("fiber", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                assertThat(ch.receive(), is(1));
-                assertThat(ch.receive(30, TimeUnit.MILLISECONDS), is(nullValue()));
-                assertThat(ch.receive(40, TimeUnit.MILLISECONDS), is(20));
-                assertThat(ch.receive(), is(200));
-                assertThat(ch.receive(), is(2000));
-                assertThat(ch.receive(), is(40));
-                assertThat(ch.receive(), is(400));
-                assertThat(ch.receive(), is(4000));
-                assertThat(ch.receive(30, TimeUnit.MILLISECONDS), is(nullValue()));
-                assertThat(ch.receive(40, TimeUnit.MILLISECONDS), is(5));
-                assertThat(ch.receive(), is(nullValue()));
-                assertThat(ch.isClosed(), is(true));
+                assertThat(ch.receive()).isEqualTo(1);
+                assertThat(ch.receive(30, TimeUnit.MILLISECONDS)).isNull();
+                assertThat(ch.receive(40, TimeUnit.MILLISECONDS)).isEqualTo(20);
+                assertThat(ch.receive()).isEqualTo(200);
+                assertThat(ch.receive()).isEqualTo(2000);
+                assertThat(ch.receive()).isEqualTo(40);
+                assertThat(ch.receive()).isEqualTo(400);
+                assertThat(ch.receive()).isEqualTo(4000);
+                assertThat(ch.receive(30, TimeUnit.MILLISECONDS)).isNull();
+                assertThat(ch.receive(40, TimeUnit.MILLISECONDS)).isEqualTo(5);
+                assertThat(ch.receive()).isNull();
+                assertThat(ch.isClosed()).isTrue();
             }
         }).start();
 
@@ -1266,7 +1271,7 @@ public class TransformingChannelTest {
                 if (x == 3)
                     return null;
                 if (x % 2 == 0)
-                    return Channels.toReceivePort(Arrays.asList(new Integer[]{x * 10, x * 100, x * 1000}));
+                    return Channels.toReceivePort(Arrays.asList(x * 10, x * 100, x * 1000));
                 else
                     return Channels.singletonReceivePort(x);
             }
@@ -1288,9 +1293,9 @@ public class TransformingChannelTest {
     public void testSendSplitThreadToFiber() throws Exception {
         final Channel<String> chF1 = newChannel();
         final Channel<String> chF2 = newChannel();
-        final SendPort<String> splitSP = new SplitSendPort<String>() {
+        final SendPort<String> splitSP = new SplitSendPort<>() {
             @Override
-            protected SendPort select(final String m) {
+            protected SendPort<String> select(final String m) {
                 if (m.equals("f1"))
                     return chF1;
                 else
@@ -1300,20 +1305,20 @@ public class TransformingChannelTest {
         final Fiber<?> f1 = new Fiber<>("split-send-1", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                assertThat(chF1.receive(), is("f1"));
-                assertThat(chF1.receive(100, TimeUnit.NANOSECONDS), is(nullValue()));
-                assertThat(chF1.receive(new Timeout(100, TimeUnit.NANOSECONDS)), is(nullValue()));
-                assertThat(chF1.receive(), is(nullValue()));
+                assertThat(chF1.receive()).isEqualTo("f1");
+                assertThat(chF1.receive(100, TimeUnit.NANOSECONDS)).isNull();
+                assertThat(chF1.receive(new Timeout(100, TimeUnit.NANOSECONDS))).isNull();
+                assertThat(chF1.receive()).isNull();
                 assertTrue(chF1.isClosed());
             }
         }).start();
         final Fiber<?> f2 = new Fiber<>("split-send-2", scheduler, new SuspendableRunnable() {
             @Override
             public void run() throws SuspendExecution, InterruptedException {
-                assertThat(chF2.receive(), is(not("f1")));
-                assertThat(chF2.receive(100, TimeUnit.NANOSECONDS), is(nullValue()));
-                assertThat(chF2.receive(new Timeout(100, TimeUnit.NANOSECONDS)), is(nullValue()));
-                assertThat(chF2.receive(), is(nullValue()));
+                assertThat(chF2.receive()).isNotEqualTo("f1");
+                assertThat(chF2.receive(100, TimeUnit.NANOSECONDS)).isNull();
+                assertThat(chF2.receive(new Timeout(100, TimeUnit.NANOSECONDS))).isNull();
+                assertThat(chF2.receive()).isNull();
                 assertTrue(chF2.isClosed());
             }
         }).start();
@@ -1335,7 +1340,7 @@ public class TransformingChannelTest {
     public void testForEach() throws Exception {
         final Channel<Integer> ch = newChannel();
 
-        Fiber<List<Integer>> fib = new Fiber<List<Integer>>("fiber", scheduler, new SuspendableCallable() {
+        Fiber<List<Integer>> fib = new Fiber<List<Integer>>("fiber", scheduler, new SuspendableCallable<>() {
             @Override
             public List<Integer> run() throws SuspendExecution, InterruptedException {
                 final List<Integer> list = new ArrayList<>();
@@ -1361,6 +1366,6 @@ public class TransformingChannelTest {
         ch.close();
 
         List<Integer> list = fib.get();
-        assertThat(list, equalTo(Arrays.asList(new Integer[]{1, 2, 3, 4, 5})));
+        assertThat(list).isEqualTo(Arrays.asList(1, 2, 3, 4, 5));
     }
 }

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/channels/transfer/PipelineTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/channels/transfer/PipelineTest.java
@@ -27,8 +27,6 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.After;
@@ -36,6 +34,10 @@ import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -120,11 +122,11 @@ public class PipelineTest {
                 final Integer m2 = o.receive();
                 final Integer m3 = o.receive();
                 final Integer m4 = o.receive();
-                assertThat(m1, notNullValue());
-                assertThat(m2, notNullValue());
-                assertThat(m3, notNullValue());
-                assertThat(m4, notNullValue());
-                assertThat(ImmutableSet.of(m1, m2, m3, m4), equalTo(ImmutableSet.of(2, 3, 4, 5)));
+                assertThat(m1).isNotNull();
+                assertThat(m2).isNotNull();
+                assertThat(m3).isNotNull();
+                assertThat(m4).isNotNull();
+                assertThat(ImmutableSet.of(m1, m2, m3, m4)).isEqualTo(ImmutableSet.of(2, 3, 4, 5));
                 try {
                     pf.join();
                 } catch (ExecutionException ex) {
@@ -144,8 +146,8 @@ public class PipelineTest {
         i.close();
 
         long transferred = pf.get(); // Join pipeline
-        assertThat(transferred, equalTo(p.getTransferred()));
-        assertThat(transferred, equalTo(4l));
+        assertThat(transferred).isEqualTo(p.getTransferred());
+        assertThat(transferred).isEqualTo(4L);
 
         receiver.join();
     }

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/dataflow/ValTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/dataflow/ValTest.java
@@ -20,15 +20,12 @@ import co.paralleluniverse.strands.Strand;
 import co.paralleluniverse.strands.SuspendableCallable;
 import co.paralleluniverse.strands.SuspendableRunnable;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
@@ -76,8 +73,8 @@ public class ValTest {
 
         t1.join();
 
-        assertThat(res.get(), equalTo("yes!"));
-        assertThat(val.get(), equalTo("yes!"));
+        assertThat(res.get()).isEqualTo("yes!");
+        assertThat(val.get()).isEqualTo("yes!");
     }
 
     @Test
@@ -98,8 +95,8 @@ public class ValTest {
 
         f1.join();
 
-        assertThat(f1.get(), equalTo("yes!"));
-        assertThat(val.get(), equalTo("yes!"));
+        assertThat(f1.get()).isEqualTo("yes!");
+        assertThat(val.get()).isEqualTo("yes!");
     }
 
     @Test
@@ -136,9 +133,9 @@ public class ValTest {
         t1.join();
         f1.join();
 
-        assertThat(f1.get(), equalTo("yes!"));
-        assertThat(res.get(), equalTo("yes!"));
-        assertThat(val.get(), equalTo("yes!"));
+        assertThat(f1.get()).isEqualTo("yes!");
+        assertThat(res.get()).isEqualTo("yes!");
+        assertThat(val.get()).isEqualTo("yes!");
     }
 
     @Test
@@ -182,9 +179,9 @@ public class ValTest {
         t1.join();
         f1.join();
 
-        assertThat(f1.get(), equalTo(13));
-        assertThat(res.get(), equalTo(40));
-        assertThat(myRes, is(3));
+        assertThat(f1.get()).isEqualTo(13);
+        assertThat(res.get()).isEqualTo(40);
+        assertThat(myRes).isEqualTo(3);
 
         f2.join();
     }
@@ -228,7 +225,7 @@ public class ValTest {
         val1.set(1);
 
         int myRes = val4.get();
-        assertThat(myRes, is(5));
+        assertThat(myRes).isEqualTo(5);
 
         t1.join();
         f1.join();

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/dataflow/VarTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/dataflow/VarTest.java
@@ -13,8 +13,6 @@
  */
 package co.paralleluniverse.strands.dataflow;
 
-import co.paralleluniverse.common.test.Matchers;
-import static co.paralleluniverse.common.test.Matchers.*;
 import co.paralleluniverse.common.test.TestUtil;
 import co.paralleluniverse.fibers.Fiber;
 import co.paralleluniverse.fibers.suspend.SuspendExecution;
@@ -24,13 +22,10 @@ import co.paralleluniverse.strands.SuspendableRunnable;
 import co.paralleluniverse.strands.channels.Channel;
 import co.paralleluniverse.strands.channels.Channels;
 import static java.util.concurrent.TimeUnit.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
@@ -73,8 +68,8 @@ public class VarTest {
 
         t1.join();
 
-        assertThat(res.get(), equalTo("yes!"));
-        assertThat(var.get(), equalTo("yes!"));
+        assertThat(res.get()).isEqualTo("yes!");
+        assertThat(var.get()).isEqualTo("yes!");
     }
 
     @Test
@@ -95,8 +90,8 @@ public class VarTest {
 
         f1.join();
 
-        assertThat(f1.get(), equalTo("yes!"));
-        assertThat(var.get(), equalTo("yes!"));
+        assertThat(f1.get()).isEqualTo("yes!");
+        assertThat(var.get()).isEqualTo("yes!");
     }
 
     @Test
@@ -133,9 +128,9 @@ public class VarTest {
         t1.join();
         f1.join();
 
-        assertThat(f1.get(), equalTo("yes!"));
-        assertThat(res.get(), equalTo("yes!"));
-        assertThat(var.get(), equalTo("yes!"));
+        assertThat(f1.get()).isEqualTo("yes!");
+        assertThat(res.get()).isEqualTo("yes!");
+        assertThat(var.get()).isEqualTo("yes!");
     }
 
     @Test
@@ -167,8 +162,8 @@ public class VarTest {
         for (int i = 0; i < 10; i++)
             var.set(i + 1);
 
-        assertThat(f1.get(), equalTo(55));
-        assertThat(f2.get(), equalTo(55));
+        assertThat(f1.get()).isEqualTo(55);
+        assertThat(f2.get()).isEqualTo(55);
     }
 
     @Test
@@ -199,7 +194,7 @@ public class VarTest {
         for (int i = 0; i < 10; i++)
             var.set(i + 1);
 
-        assertThat(f1.get(), not(equalTo(55)));
+        assertThat(f1.get()).isNotEqualTo(55);
         f2.join();
     }
 
@@ -221,24 +216,24 @@ public class VarTest {
         });
 
         b.set(2);
-        assertThat(ch.receive(50, MILLISECONDS), is(nullValue()));
+        assertThat(ch.receive(50, MILLISECONDS)).isNull();
 
         a.set(1);
-        assertThat(ch.receive(50, MILLISECONDS), is(3));
+        assertThat(ch.receive(50, MILLISECONDS)).isEqualTo(3);
 
-        assertThat(ch.receive(), is(3));
+        assertThat(ch.receive()).isEqualTo(3);
 
-        assertThat(ch.receive(50, MILLISECONDS), is(nullValue()));
+        assertThat(ch.receive(50, MILLISECONDS)).isNull();
 
         a.set(2);
-        assertThat(ch.receive(), is(4));
+        assertThat(ch.receive()).isEqualTo(4);
 
-        assertThat(ch.receive(50, MILLISECONDS), is(nullValue()));
+        assertThat(ch.receive(50, MILLISECONDS)).isNull();
         b.set(3);
-        assertThat(ch.receive(50, MILLISECONDS), is(5));
+        assertThat(ch.receive(50, MILLISECONDS)).isEqualTo(5);
 
-        assertThat(ch.receive(50, MILLISECONDS), is(nullValue()));
+        assertThat(ch.receive(50, MILLISECONDS)).isNull();
         a.set(4);
-        assertThat(ch.receive(50, MILLISECONDS), is(7));
+        assertThat(ch.receive(50, MILLISECONDS)).isEqualTo(7);
     }
 }

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/queues/SingleConsumerPrimitiveQueueTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/queues/SingleConsumerPrimitiveQueueTest.java
@@ -21,14 +21,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Queue;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Simple, single-threaded tests
@@ -81,10 +83,10 @@ public class SingleConsumerPrimitiveQueueTest {
     }
 
     private void testEmptyQueue(SingleConsumerQueue<?> queue) {
-        assertThat(queue.size(), is(0));
+        assertThat(queue.size()).isEqualTo(0);
         assertTrue(queue.isEmpty());
-        assertThat(queue.peek(), is(nullValue()));
-        assertThat(queue.poll(), is(nullValue()));
+        assertThat(queue.peek()).isNull();
+        assertThat(queue.poll()).isNull();
         try {
             queue.element();
             fail();
@@ -103,18 +105,18 @@ public class SingleConsumerPrimitiveQueueTest {
         wordQueue.offer(2);
         wordQueue.offer(3);
 
-        assertThat(wordQueue.isEmpty(), is(false));
-        assertThat(wordQueue.size(), is(3));
-        assertThat(wordQueue.peek(), is(1));
-        assertThat(list(wordQueue), is(equalTo(list(1, 2, 3))));
+        assertThat(wordQueue.isEmpty()).isFalse();
+        assertThat(wordQueue.size()).isEqualTo(3);
+        assertThat(wordQueue.peek()).isEqualTo(1);
+        assertThat(list(wordQueue)).isEqualTo(list(1, 2, 3));
 
         dwordQueue.offer(1.2);
         dwordQueue.offer(2.3);
         dwordQueue.offer(3.4);
 
-        assertThat(dwordQueue.isEmpty(), is(false));
-        assertThat(dwordQueue.size(), is(3));
-        assertThat(list(dwordQueue), is(equalTo(list(1.2, 2.3, 3.4))));
+        assertThat(dwordQueue.isEmpty()).isFalse();
+        assertThat(dwordQueue.size()).isEqualTo(3);
+        assertThat(list(dwordQueue)).isEqualTo(list(1.2, 2.3, 3.4));
     }
 
     @Test
@@ -125,14 +127,14 @@ public class SingleConsumerPrimitiveQueueTest {
             wordQueue.offer((j++));
             wordQueue.offer((j++));
             Integer s = wordQueue.poll();
-            assertThat(s, equalTo((k++)));
+            assertThat(s).isEqualTo(k++);
         }
-        assertThat(wordQueue.size(), is(8));
-        assertThat(list(wordQueue), is(equalTo(list(9, 10, 11, 12, 13, 14, 15, 16))));
+        assertThat(wordQueue.size()).isEqualTo(8);
+        assertThat(list(wordQueue)).isEqualTo(list(9, 10, 11, 12, 13, 14, 15, 16));
 
         for (int i = 0; i < 8; i++) {
             Integer s = wordQueue.poll();
-            assertThat(s, equalTo((k++)));
+            assertThat(s).isEqualTo(k++);
         }
         testEmptyQueue(wordQueue);
 
@@ -142,14 +144,14 @@ public class SingleConsumerPrimitiveQueueTest {
             dwordQueue.offer(0.1 + (j++));
             dwordQueue.offer(0.1 + (j++));
             Double s = dwordQueue.poll();
-            assertThat(s, equalTo(0.1 + (k++)));
+            assertThat(s).isEqualTo(0.1 + (k++));
         }
-        assertThat(dwordQueue.size(), is(8));
-        assertThat(list(dwordQueue), is(equalTo(list(9.1, 10.1, 11.1, 12.1, 13.1, 14.1, 15.1, 16.1))));
+        assertThat(dwordQueue.size()).isEqualTo(8);
+        assertThat(list(dwordQueue)).isEqualTo(list(9.1, 10.1, 11.1, 12.1, 13.1, 14.1, 15.1, 16.1));
 
         for (int i = 0; i < 8; i++) {
             Double s = dwordQueue.poll();
-            assertThat(s, equalTo(0.1 + (k++)));
+            assertThat(s).isEqualTo(0.1 + (k++));
         }
         testEmptyQueue(dwordQueue);
     }
@@ -168,7 +170,7 @@ public class SingleConsumerPrimitiveQueueTest {
                 it.remove();
         }
 
-        assertThat(list(wordQueue), is(equalTo(list(1, 3, 5, 7, 9))));
+        assertThat(list(wordQueue)).isEqualTo(list(1, 3, 5, 7, 9));
 
         for (int i = 0; i < 4; i++)
             wordQueue.offer((j++));
@@ -180,7 +182,7 @@ public class SingleConsumerPrimitiveQueueTest {
                 it.remove();
         }
 
-        assertThat(list(wordQueue), is(equalTo(list(3, 7, 10, 12))));
+        assertThat(list(wordQueue)).isEqualTo(list(3, 7, 10, 12));
 
         j = 1;
         k = 1;
@@ -194,7 +196,7 @@ public class SingleConsumerPrimitiveQueueTest {
                 it.remove();
         }
 
-        assertThat(list(dwordQueue), is(equalTo(list(1.1, 3.1, 5.1, 7.1, 9.1))));
+        assertThat(list(dwordQueue)).isEqualTo(list(1.1, 3.1, 5.1, 7.1, 9.1));
 
         for (int i = 0; i < 4; i++)
             dwordQueue.offer(0.1 + (j++));
@@ -206,7 +208,7 @@ public class SingleConsumerPrimitiveQueueTest {
                 it.remove();
         }
 
-        assertThat(list(dwordQueue), is(equalTo(list(3.1, 7.1, 10.1, 12.1))));
+        assertThat(list(dwordQueue)).isEqualTo(list(3.1, 7.1, 10.1, 12.1));
     }
 
     @Test
@@ -223,8 +225,8 @@ public class SingleConsumerPrimitiveQueueTest {
             it.next();
             it.remove();
 
-            assertThat(wordQueue.size(), is(2));
-            assertThat(list(wordQueue), is(equalTo(list(3, 4))));
+            assertThat(wordQueue.size()).isEqualTo(2);
+            assertThat(list(wordQueue)).isEqualTo(list(3, 4));
 
             wordQueue.offer(5);
             wordQueue.offer(6);
@@ -234,8 +236,8 @@ public class SingleConsumerPrimitiveQueueTest {
             it.next();
             it.remove();
 
-            assertThat(wordQueue.size(), is(2));
-            assertThat(list(wordQueue), is(equalTo(list(5, 6))));
+            assertThat(wordQueue.size()).isEqualTo(2);
+            assertThat(list(wordQueue)).isEqualTo(list(5, 6));
         }
 
         {
@@ -250,8 +252,8 @@ public class SingleConsumerPrimitiveQueueTest {
             it.next();
             it.remove();
 
-            assertThat(dwordQueue.size(), is(2));
-            assertThat(list(dwordQueue), is(equalTo(list(3.4, 4.5))));
+            assertThat(dwordQueue.size()).isEqualTo(2);
+            assertThat(list(dwordQueue)).isEqualTo(list(3.4, 4.5));
 
             dwordQueue.offer(5.6);
             dwordQueue.offer(6.7);
@@ -261,8 +263,8 @@ public class SingleConsumerPrimitiveQueueTest {
             it.next();
             it.remove();
 
-            assertThat(dwordQueue.size(), is(2));
-            assertThat(list(dwordQueue), is(equalTo(list(5.6, 6.7))));
+            assertThat(dwordQueue.size()).isEqualTo(2);
+            assertThat(list(dwordQueue)).isEqualTo(list(5.6, 6.7));
         }
     }
 
@@ -284,8 +286,8 @@ public class SingleConsumerPrimitiveQueueTest {
                 it.next();
             it.remove();
 
-            assertThat(wordQueue.size(), is(2));
-            assertThat(list(wordQueue), is(equalTo(list(1, 2))));
+            assertThat(wordQueue.size()).isEqualTo(2);
+            assertThat(list(wordQueue)).isEqualTo(list(1, 2));
 
             wordQueue.offer(5);
             wordQueue.offer(6);
@@ -300,8 +302,8 @@ public class SingleConsumerPrimitiveQueueTest {
                 it.next();
             it.remove();
 
-            assertThat(wordQueue.size(), is(2));
-            assertThat(list(wordQueue), is(equalTo(list(1, 2))));
+            assertThat(wordQueue.size()).isEqualTo(2);
+            assertThat(list(wordQueue)).isEqualTo(list(1, 2));
         }
 
         {
@@ -320,8 +322,8 @@ public class SingleConsumerPrimitiveQueueTest {
                 it.next();
             it.remove();
 
-            assertThat(dwordQueue.size(), is(2));
-            assertThat(list(dwordQueue), is(equalTo(list(1.2, 2.3))));
+            assertThat(dwordQueue.size()).isEqualTo(2);
+            assertThat(list(dwordQueue)).isEqualTo(list(1.2, 2.3));
 
             dwordQueue.offer(5.6);
             dwordQueue.offer(6.7);
@@ -336,8 +338,8 @@ public class SingleConsumerPrimitiveQueueTest {
                 it.next();
             it.remove();
 
-            assertThat(dwordQueue.size(), is(2));
-            assertThat(list(dwordQueue), is(equalTo(list(1.2, 2.3))));
+            assertThat(dwordQueue.size()).isEqualTo(2);
+            assertThat(list(dwordQueue)).isEqualTo(list(1.2, 2.3));
         }
     }
 
@@ -352,8 +354,8 @@ public class SingleConsumerPrimitiveQueueTest {
             testEmptyQueue(wordQueue);
 
             wordQueue.offer(1);
-            assertThat(wordQueue.size(), is(1));
-            assertThat(list(wordQueue), is(equalTo(list(1))));
+            assertThat(wordQueue.size()).isEqualTo(1);
+            assertThat(list(wordQueue)).isEqualTo(list(1));
 
             it = wordQueue.iterator();
             it.next();
@@ -362,8 +364,8 @@ public class SingleConsumerPrimitiveQueueTest {
             testEmptyQueue(wordQueue);
 
             wordQueue.offer(1);
-            assertThat(wordQueue.size(), is(1));
-            assertThat(list(wordQueue), is(equalTo(list(1))));
+            assertThat(wordQueue.size()).isEqualTo(1);
+            assertThat(list(wordQueue)).isEqualTo(list(1));
         }
 
         {
@@ -375,8 +377,8 @@ public class SingleConsumerPrimitiveQueueTest {
             testEmptyQueue(dwordQueue);
 
             dwordQueue.offer(1.2);
-            assertThat(dwordQueue.size(), is(1));
-            assertThat(list(dwordQueue), is(equalTo(list(1.2))));
+            assertThat(dwordQueue.size()).isEqualTo(1);
+            assertThat(list(dwordQueue)).isEqualTo(list(1.2));
 
             it = dwordQueue.iterator();
             it.next();
@@ -385,8 +387,8 @@ public class SingleConsumerPrimitiveQueueTest {
             testEmptyQueue(dwordQueue);
 
             dwordQueue.offer(1.2);
-            assertThat(dwordQueue.size(), is(1));
-            assertThat(list(dwordQueue), is(equalTo(list(1.2))));
+            assertThat(dwordQueue.size()).isEqualTo(1);
+            assertThat(list(dwordQueue)).isEqualTo(list(1.2));
         }
     }
 

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/queues/SingleConsumerQueueTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/queues/SingleConsumerQueueTest.java
@@ -21,14 +21,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Queue;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Simple, single-threaded tests
@@ -71,10 +73,10 @@ public class SingleConsumerQueueTest {
 
     @Test
     public void testEmptyQueue() {
-        assertThat(queue.size(), is(0));
+        assertThat(queue.size()).isEqualTo(0);
         assertTrue(queue.isEmpty());
-        assertThat(queue.peek(), is(nullValue()));
-        assertThat(queue.poll(), is(nullValue()));
+        assertThat(queue.peek()).isNull();
+        assertThat(queue.poll()).isNull();
         try {
             queue.element();
             fail();
@@ -93,9 +95,9 @@ public class SingleConsumerQueueTest {
         queue.offer("two");
         queue.offer("three");
 
-        assertThat(queue.isEmpty(), is(false));
-        assertThat(queue.size(), is(3));
-        assertThat(list(queue), is(equalTo(list("one", "two", "three"))));
+        assertThat(queue.isEmpty()).isFalse();
+        assertThat(queue.size()).isEqualTo(3);
+        assertThat(list(queue)).isEqualTo(list("one", "two", "three"));
     }
 
     @Test
@@ -106,14 +108,14 @@ public class SingleConsumerQueueTest {
             queue.offer("x" + (j++));
             queue.offer("x" + (j++));
             String s = queue.poll();
-            assertThat(s, equalTo("x" + (k++)));
+            assertThat(s).isEqualTo("x" + (k++));
         }
-        assertThat(queue.size(), is(8));
-        assertThat(list(queue), is(equalTo(list("x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16"))));
+        assertThat(queue.size()).isEqualTo(8);
+        assertThat(list(queue)).isEqualTo(list("x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16"));
 
         for (int i = 0; i < 8; i++) {
             String s = queue.poll();
-            assertThat(s, equalTo("x" + (k++)));
+            assertThat(s).isEqualTo("x" + (k++));
         }
         testEmptyQueue();
     }
@@ -132,7 +134,7 @@ public class SingleConsumerQueueTest {
                 it.remove();
         }
 
-        assertThat(list(queue), is(equalTo(list("x1", "x3", "x5", "x7", "x9"))));
+        assertThat(list(queue)).isEqualTo(list("x1", "x3", "x5", "x7", "x9"));
 
         for (int i = 0; i < 4; i++)
             queue.offer("x" + (j++));
@@ -144,7 +146,7 @@ public class SingleConsumerQueueTest {
                 it.remove();
         }
 
-        assertThat(list(queue), is(equalTo(list("x3", "x7", "x10", "x12"))));
+        assertThat(list(queue)).isEqualTo(list("x3", "x7", "x10", "x12"));
     }
 
     @Test
@@ -160,8 +162,8 @@ public class SingleConsumerQueueTest {
         it.next();
         it.remove();
 
-        assertThat(queue.size(), is(2));
-        assertThat(list(queue), is(equalTo(list("three", "four"))));
+        assertThat(queue.size()).isEqualTo(2);
+        assertThat(list(queue)).isEqualTo(list("three", "four"));
 
         queue.offer("five");
         queue.offer("six");
@@ -171,8 +173,8 @@ public class SingleConsumerQueueTest {
         it.next();
         it.remove();
 
-        assertThat(queue.size(), is(2));
-        assertThat(list(queue), is(equalTo(list("five", "six"))));
+        assertThat(queue.size()).isEqualTo(2);
+        assertThat(list(queue)).isEqualTo(list("five", "six"));
     }
 
     @Test
@@ -192,8 +194,8 @@ public class SingleConsumerQueueTest {
             it.next();
         it.remove();
 
-        assertThat(queue.size(), is(2));
-        assertThat(list(queue), is(equalTo(list("one", "two"))));
+        assertThat(queue.size()).isEqualTo(2);
+        assertThat(list(queue)).isEqualTo(list("one", "two"));
 
         queue.offer("five");
         queue.offer("six");
@@ -208,8 +210,8 @@ public class SingleConsumerQueueTest {
             it.next();
         it.remove();
 
-        assertThat(queue.size(), is(2));
-        assertThat(list(queue), is(equalTo(list("one", "two"))));
+        assertThat(queue.size()).isEqualTo(2);
+        assertThat(list(queue)).isEqualTo(list("one", "two"));
     }
 
     @Test
@@ -222,8 +224,8 @@ public class SingleConsumerQueueTest {
         testEmptyQueue();
 
         queue.offer("one");
-        assertThat(queue.size(), is(1));
-        assertThat(list(queue), is(equalTo(list("one"))));
+        assertThat(queue.size()).isEqualTo(1);
+        assertThat(list(queue)).isEqualTo(list("one"));
 
         it = queue.iterator();
         it.next();
@@ -232,8 +234,8 @@ public class SingleConsumerQueueTest {
         testEmptyQueue();
 
         queue.offer("one");
-        assertThat(queue.size(), is(1));
-        assertThat(list(queue), is(equalTo(list("one"))));
+        assertThat(queue.size()).isEqualTo(1);
+        assertThat(list(queue)).isEqualTo(list("one"));
     }
 
     private static <E> List<E> list(Queue<E> queue) {

--- a/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/FiberAsyncTest.kt
+++ b/quasar-kotlin/src/test/kotlin/co/paralleluniverse/kotlin/fibers/FiberAsyncTest.kt
@@ -20,8 +20,7 @@ import co.paralleluniverse.fibers.FiberForkJoinScheduler
 import co.paralleluniverse.fibers.Suspendable
 import co.paralleluniverse.strands.Strand
 import co.paralleluniverse.strands.SuspendableRunnable
-import org.hamcrest.CoreMatchers.equalTo
-import org.junit.Assert.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
 import java.util.concurrent.Executors
@@ -125,7 +124,7 @@ class FiberAsyncTest {
     fun testSyncCallback() {
         val fiber = Fiber<Void>(scheduler, SuspendableRunnable @Suspendable {
             val res = callService(syncService)
-            assertThat(res, equalTo("sync result!"))
+            assertThat(res).isEqualTo("sync result!")
         }).start()
 
         fiber.join()
@@ -138,7 +137,7 @@ class FiberAsyncTest {
                 callService(badSyncService)
                 fail()
             } catch (e: Exception) {
-                assertThat(e.message, equalTo("sync exception!"))
+                assertThat(e.message).isEqualTo("sync exception!")
             }
         }).start()
 
@@ -149,7 +148,7 @@ class FiberAsyncTest {
     fun testAsyncCallback() {
         val fiber = Fiber<Void>(scheduler, SuspendableRunnable @Suspendable {
             val res = callService(asyncService)
-            assertThat(res, equalTo("async result!"))
+            assertThat(res).isEqualTo("async result!")
         }).start()
 
         fiber.join()
@@ -162,7 +161,7 @@ class FiberAsyncTest {
                 callService(badAsyncService)
                 fail()
             } catch (e: Exception) {
-                assertThat(e.message, equalTo("async exception!"))
+                assertThat(e.message).isEqualTo("async exception!")
             }
         }).start()
 
@@ -180,7 +179,7 @@ class FiberAsyncTest {
                 }.run()
                 fail()
             } catch (e: Exception) {
-                assertThat(e.message, equalTo("requestAsync exception!"))
+                assertThat(e.message).isEqualTo("requestAsync exception!")
             }
         }).start()
 
@@ -192,7 +191,7 @@ class FiberAsyncTest {
         val fiber = Fiber<Void>(scheduler, SuspendableRunnable @Suspendable {
             try {
                 val res = callService(asyncService, 100, TimeUnit.MILLISECONDS)
-                assertThat(res, equalTo("async result!"))
+                assertThat(res).isEqualTo("async result!")
             } catch (e: TimeoutException) {
                 throw RuntimeException()
             }
@@ -247,7 +246,7 @@ class FiberAsyncTest {
                 Strand.sleep(300)
                 "ok"
             })
-            assertThat(res, equalTo("ok"))
+            assertThat(res).isEqualTo("ok")
         }).start()
 
         fiber.join()
@@ -261,7 +260,7 @@ class FiberAsyncTest {
                     Strand.sleep(300)
                     "ok"
                 })
-                assertThat(res, equalTo("ok"))
+                assertThat(res).isEqualTo("ok")
             } catch (e: TimeoutException) {
                 fail()
             }


### PR DESCRIPTION
Avoid using `ClassLoader.getResource()` too many times, because this function is recursive and so potentially expensive to invoke inside a loop. We can optimise for the case when a `ClassLoader` is also a `URLClassLoader` by comparing the class resource URL with `URLClassLoader.getURLs()`. For `jrt:/` resources, we can determine the Java module from the URL's path, and hence the module's classloader directly.

Also resolve at least some of the :christmas_tree: "Christmas Tree" :christmas_tree: of warnings triggered by upgrading JUnit 4.12 -> 4.13.2.