### PR TITLE
CORE-5017: Upgrade to ASM 9.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ subprojects {
 
     ext.drpWizVer = '4.1.0'
     ext.guavaVer  = '30.1.1-jre'
-    ext.asmVer    = '7.0'
     ext.slf4jVer  = '1.7.36'
     ext.osgiVer   = '8.0.0'
     ext.osgiComponentVer = '1.4.0'
@@ -75,7 +74,7 @@ subprojects {
         resolutionStrategy {
             dependencySubstitution {
                 // The substitution is needed to get ASM 7.0 whilst Kryo still depends on 5.0.4
-                substitute module("org.ow2.asm:asm") with module("org.ow2.asm:asm:$asmVer")
+                substitute module("org.ow2.asm:asm") with module("org.ow2.asm:asm:$asmVersion")
 
                 // Kryo demands Objenesis 2.5.1, but Mockito wants Objenesis 2.6
                 substitute module("org.objenesis:objenesis") with module("org.objenesis:objenesis:2.5.1")
@@ -134,7 +133,7 @@ subprojects {
             exclude group: "net.bytebuddy", module: '*'
         }
         testRuntimeOnly "net.bytebuddy:byte-buddy:1.9.2" // for Mockito
-        testImplementation "org.ow2.asm:asm:$asmVer"
+        testImplementation "org.ow2.asm:asm:$asmVersion"
 
         jmhImplementation 'org.openjdk.jmh:jmh-core:1.21'
         jmhImplementation 'org.openjdk.jmh:jmh-generator-annprocess:1.21'
@@ -452,10 +451,10 @@ project (':quasar-core') {
         implementation("org.latencyutils:LatencyUtils:2.0.3") {
             exclude group: "org.hdrhistogram", module: '*'
         }
-        provided "org.ow2.asm:asm:$asmVer"
-        provided "org.ow2.asm:asm-analysis:$asmVer"
-        provided "org.ow2.asm:asm-commons:$asmVer"
-        provided "org.ow2.asm:asm-util:$asmVer"
+        provided "org.ow2.asm:asm:$asmVersion"
+        provided "org.ow2.asm:asm-analysis:$asmVersion"
+        provided "org.ow2.asm:asm-commons:$asmVersion"
+        provided "org.ow2.asm:asm-util:$asmVersion"
 
         implementation "com.esotericsoftware:kryo:4.0.2"
         implementation "de.javakaffee:kryo-serializers:0.43"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,8 @@ modulepluginVersion=1.7.0
 
 kotlin.stdlib.default.dependency=false
 
+asmVersion=9.3
+
 felixVersion=7.0.3
 felixConfigAdminVersion=1.9.22
 felixLogVersion=1.2.6

--- a/quasar-core/src/main/java/co/paralleluniverse/common/asm/ASMUtil.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/asm/ASMUtil.java
@@ -18,7 +18,7 @@ import static co.paralleluniverse.common.resource.ClassLoaderUtil.classToSlashed
 import static org.objectweb.asm.ClassReader.SKIP_FRAMES;
 
 public final class ASMUtil {
-    public static final int ASMAPI = Opcodes.ASM7;
+    public static final int ASMAPI = Opcodes.ASM9;
 
     public static void findMethod(
         Class<?> clazz,

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/ModuleFilterTask.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/ModuleFilterTask.java
@@ -17,9 +17,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
-import java.util.List;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Task;
@@ -28,7 +26,8 @@ import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.ModuleVisitor;
-import org.objectweb.asm.Opcodes;
+
+import static co.paralleluniverse.common.asm.ASMUtil.ASMAPI;
 
 /**
  * <p>
@@ -50,9 +49,6 @@ public class ModuleFilterTask extends Task {
     @Override
     public void execute() throws BuildException {
         try {
-            final List<URL> urls = new ArrayList<>();
-
-
             for (FileSet fs : filesets) {
                 final DirectoryScanner ds = fs.getDirectoryScanner(getProject());
                 final String[] includedFiles = ds.getIncludedFiles();
@@ -76,14 +72,14 @@ public class ModuleFilterTask extends Task {
 
     private void filter(File file) {
         try {
-            ClassWriter cw = null;
+            ClassWriter cw;
             try (FileInputStream fis = new FileInputStream(file)) {
                 ClassReader cr = new ClassReader(fis);
                 cw = new ClassWriter(cr, 0);
-                cr.accept(new ClassVisitor(Opcodes.ASM7, cw) {
+                cr.accept(new ClassVisitor(ASMAPI, cw) {
                     @Override
                     public ModuleVisitor visitModule(String name, int access, String version) {
-                        return new ModuleVisitor(Opcodes.ASM7, super.visitModule(name, access, version)) {
+                        return new ModuleVisitor(api, super.visitModule(name, access, version)) {
                             @Override
                             public void visitRequire(String module, int access, String version) {
                                 if (!module.contains(mod)) {

--- a/quasar-osgi-tests/tests.bndrun
+++ b/quasar-osgi-tests/tests.bndrun
@@ -12,7 +12,7 @@
     --add-opens, 'java.base/java.net=ALL-UNNAMED'
 -runpath: \
     com.esotericsoftware.reflectasm;version=${project.reflectAsmVersion},\
-    org.objectweb.asm;version=${project.asmVer}
+    org.objectweb.asm;version=${project.asmVersion}
 -runsystempackages: \
     co.paralleluniverse.fibers.instrument;version=${project.quasarOsgiVersion},\
     co.paralleluniverse.fibers.suspend;version=${project.quasarOsgiVersion},\


### PR DESCRIPTION
Upgrade ASM 7.0 -> 9.3

ASM 9.3 includes support for Java 19 and below, which allows the Quasar agent to be applied to a Java 17 JVM without any catastrophic errors. It also allows Quasar's Gradle build to run on Java 17.

Note that it doesn't mean that Quasar _works_ on Java 17; just that it won't trigger an endless stream of exceptions!