### PR TITLE
CORE-5456: Abort instrumenting if we cannot determine any common super class.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -923,7 +923,7 @@ configure(publishedProjects) { subproject ->
 
 artifactory {
     publish {
-        contextUrl = 'https://software.r3.com/artifactory'
+        contextUrl = artifactoryContextUrl
         repository {
             repoKey = System.getenv('CORDA_ARTIFACTORY_REPOKEY') ?: 'corda-dependencies-dev'
             username = project.findProperty('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: System.getProperty('corda.artifactory.username')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 quasarVersion=0.8.8_r3-SNAPSHOT
-kotlinVersion=1.6.21
+kotlinVersion=1.7.0
 taskTreeVersion=1.3.1
 shadowVersion=6.1.0
 artifactoryVersion=4.21.0
@@ -22,6 +22,8 @@ junitPlatformVersion=1.8.2
 osgiTestJunit5Version=1.1.0
 osgiUtilFunctionVersion=1.1.0
 osgiUtilPromiseVersion=1.2.0
+
+artifactoryContextUrl=https://software.r3.com/artifactory
 
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g -Dfile.encoding=UTF-8
 org.gradle.java.installations.auto-download=false

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/DBClassWriter.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/DBClassWriter.java
@@ -37,7 +37,6 @@ import org.objectweb.asm.ClassWriter;
  * @author Matthias Mann
  */
 class DBClassWriter extends ClassWriter {
-
     private final MethodDatabase db;
 
     DBClassWriter(MethodDatabase db, ClassReader classReader) {
@@ -47,6 +46,15 @@ class DBClassWriter extends ClassWriter {
 
     @Override
     protected String getCommonSuperClass(String type1, String type2) {
-        return db.getCommonSuperClass(type1, type2);
+        final String commonSuperClass = db.getCommonSuperClass(type1, type2);
+
+        // ASM does not expect ClassWriter.getCommonSuperClass() to return null.
+        // However, we cannot safely assume that we can return java.lang.Object
+        // if it does, e.g. finding a common Throwable type inside a catch block.
+        // Abort instrumenting this class rather than risk generating broken code.
+        if (commonSuperClass == null) {
+            throw new IllegalStateException("Cannot determine common super class of [" + type1 + ',' + type2 + ']');
+        }
+        return commonSuperClass;
     }
 }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
@@ -52,6 +52,7 @@ import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.security.PrivilegedAction;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -348,24 +349,23 @@ public final class MethodDatabase {
             // byte-code!
             return JAVA_OBJECT;
         }
-        final List<String> listA = getSuperClasses(classA);
-        final List<String> listB = getSuperClasses(classB);
+        final Deque<String> listA = getSuperClasses(classA);
+        final Deque<String> listB = getSuperClasses(classB);
         if (listA == null || listB == null) {
             return null;
         }
-        final int num = Math.min(listA.size(), listB.size());
-        int idx = 0;
-        for (; idx < num; idx++) {
-            final String superClassA = listA.get(idx);
-            final String superClassB = listB.get(idx);
+        String commonSuperClass = JAVA_OBJECT;
+        int count = Math.min(listA.size(), listB.size());
+        while (count > 0) {
+            final String superClassA = listA.removeFirst();
+            final String superClassB = listB.removeFirst();
             if (!superClassA.equals(superClassB)) {
                 break;
             }
+            commonSuperClass = superClassA;
+            --count;
         }
-        if (idx > 0) {
-            return listA.get(idx - 1);
-        }
-        return null;
+        return commonSuperClass;
     }
 
     public boolean isException(final String className) {
@@ -433,8 +433,8 @@ public final class MethodDatabase {
         }
     }
 
-    private List<String> getSuperClasses(final String className) {
-        final LinkedList<String> result = new LinkedList<>();
+    private Deque<String> getSuperClasses(final String className) {
+        final Deque<String> result = new LinkedList<>();
         String currentClassName = className;
         MethodDatabase currentDB = this;
         for (;;) {


### PR DESCRIPTION
ASM expects `ClassWriter.getCommonSuperClass(String, String)` to throw `TypeNotPresentException` if it fails, whereas we were just returning `null`. We cannot assume that we can fall back to using `java.lang.Object` in this case because a `try-catch` block would require two exceptions still to be `Throwable`. So we have no choice but to abort instrumenting that particular class entirely.

And a small update to the Gradle files while we're here.