### PR TITLE
CORE-5456: Abort instrumenting if we cannot determine any common super class.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -808,7 +808,7 @@ configure(publishedProjects) { subproject ->
 
 artifactory {
     publish {
-        contextUrl = 'https://software.r3.com/artifactory'
+        contextUrl = artifactoryContextUrl
         repository {
             repoKey = System.getenv('CORDA_ARTIFACTORY_REPOKEY') ?: 'corda-dependencies-dev'
             username = project.findProperty('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: System.getProperty('corda.artifactory.username')

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,8 @@ bndVersion=6.2.0
 kotlin.stdlib.default.dependency=false
 kotlin.incremental=true
 
+artifactoryContextUrl=https://software.r3.com/artifactory
+
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g -Dfile.encoding=UTF-8
 org.gradle.java.installations.auto-download=false
 org.gradle.caching=false

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/DBClassWriter.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/DBClassWriter.java
@@ -37,7 +37,6 @@ import org.objectweb.asm.ClassWriter;
  * @author Matthias Mann
  */
 class DBClassWriter extends ClassWriter {
-
     private final MethodDatabase db;
 
     DBClassWriter(MethodDatabase db, ClassReader classReader) {
@@ -47,6 +46,15 @@ class DBClassWriter extends ClassWriter {
 
     @Override
     protected String getCommonSuperClass(String type1, String type2) {
-        return db.getCommonSuperClass(type1, type2);
+        final String commonSuperClass = db.getCommonSuperClass(type1, type2);
+
+        // ASM does not expect ClassWriter.getCommonSuperClass() to return null.
+        // However, we cannot safely assume that we can return java.lang.Object
+        // if it does, e.g. finding a common Throwable type inside a catch block.
+        // Abort instrumenting this class rather than risk generating broken code.
+        if (commonSuperClass == null) {
+            throw new IllegalStateException("Cannot determine common super class of [" + type1 + ',' + type2 + ']');
+        }
+        return commonSuperClass;
     }
 }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
@@ -57,6 +57,7 @@ import java.io.UncheckedIOException;
 import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -340,24 +341,23 @@ public final class MethodDatabase {
         if (JAVA_OBJECT.equals(classA) || JAVA_OBJECT.equals(classB)) {
             return JAVA_OBJECT;
         }
-        final List<String> listA = getSuperClasses(classA);
-        final List<String> listB = getSuperClasses(classB);
+        final Deque<String> listA = getSuperClasses(classA);
+        final Deque<String> listB = getSuperClasses(classB);
         if (listA == null || listB == null) {
             return null;
         }
-        final int num = Math.min(listA.size(), listB.size());
-        int idx = 0;
-        for (; idx < num; idx++) {
-            final String superClassA = listA.get(idx);
-            final String superClassB = listB.get(idx);
+        String commonSuperClass = JAVA_OBJECT;
+        int count = Math.min(listA.size(), listB.size());
+        while (count > 0) {
+            final String superClassA = listA.removeFirst();
+            final String superClassB = listB.removeFirst();
             if (!superClassA.equals(superClassB)) {
                 break;
             }
+            commonSuperClass = superClassA;
+            --count;
         }
-        if (idx > 0) {
-            return listA.get(idx - 1);
-        }
-        return null;
+        return commonSuperClass;
     }
 
     public boolean isException(final String className) {
@@ -420,8 +420,8 @@ public final class MethodDatabase {
         }
     }
 
-    private List<String> getSuperClasses(final String className) {
-        final LinkedList<String> result = new LinkedList<>();
+    private Deque<String> getSuperClasses(final String className) {
+        final Deque<String> result = new LinkedList<>();
         String currentClassName = className;
         MethodDatabase currentDB = this;
         for (;;) {


### PR DESCRIPTION
ASM expects `ClassWriter.getCommonSuperClass(String, String)` to throw `TypeNotPresentException` if it fails. However, we need our Java agent to be more forgiving than that, so use `Object` instead. (Although the common super class of two exceptions inside a `catch` block would almost certainly need to be `Throwable` rather than `Object`.)

And a small update to the Gradle files while we're here.