### PR TITLE
NOTICK: Allow checking instrumentation when SecurityManager installed.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberHelper.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberHelper.java
@@ -98,16 +98,17 @@ final class FiberHelper {
                     for (String callsite : callsites) {
                         if (callsite.endsWith(nameAndDescSuffix)) {
                             final String ownerName = getCallsiteOwner(callsite);
-                            Class<?> callsiteOwner;
-                            try {
-                                callsiteOwner = Class.forName(ownerName, true, Thread.currentThread().getContextClassLoader());
-                            } catch (ClassNotFoundException e) {
+                            final Class<?> callsiteOwner = doPrivileged((PrivilegedAction<Class<?>>)() -> {
                                 try {
-                                    callsiteOwner = Class.forName(ownerName, true, FiberHelper.class.getClassLoader());
-                                } catch (ClassNotFoundException e2) {
-                                    callsiteOwner = null;
+                                    return Class.forName(ownerName, true, Thread.currentThread().getContextClassLoader());
+                                } catch (ClassNotFoundException e) {
+                                    try {
+                                        return Class.forName(ownerName, true, FiberHelper.class.getClassLoader());
+                                    } catch (ClassNotFoundException e2) {
+                                        return null;
+                                    }
                                 }
-                            }
+                            });
                             if (callsiteOwner != null) {
                                 final Class<?> owner = callee.getDeclaringClass();
                                 if (doPrivileged(new DeclareInCommonAncestor(nameAndDescSuffix, owner, callsiteOwner))) {


### PR DESCRIPTION
Allow Quasar agent to get classloaders and load classes when the JVM has a SecurityManager installed, so that it can still verify instrumentation.