### PR TITLE
NOTICK: Upgrade Kotlin tests to use Kotlin 1.7.10.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 quasarVersion=0.8.8_r3-SNAPSHOT
-kotlinVersion=1.7.0
+kotlinVersion=1.7.10
 taskTreeVersion=1.3.1
 shadowVersion=6.1.0
 artifactoryVersion=4.21.0

--- a/quasar-kotlin/build.gradle
+++ b/quasar-kotlin/build.gradle
@@ -58,8 +58,8 @@ tasks.named('check') {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
         jvmTarget = '11'
-        apiVersion = '1.6'
-        languageVersion = '1.6'
+        apiVersion = '1.7'
+        languageVersion = '1.7'
         allWarningsAsErrors = true
         // We need to enable this, but must watch for compiler warnings about
         // abstract methods in the base class not having an implementation!


### PR DESCRIPTION
Test Quasar with the latest version of Kotlin, i.e. 1.7.10.