### PR TITLE
CORE-5938: Acknowledge Azul JDK platform contains extra packages.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
@@ -62,6 +62,7 @@ import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 
 import static co.paralleluniverse.fibers.instrument.Classes.isYieldMethod;
 import static java.security.AccessController.doPrivileged;
@@ -95,6 +96,12 @@ public final class MethodDatabase {
         "jcp/xml/",
         "ietf/jgss/"
     );
+
+    private static final Predicate<String> isJDK;
+    static {
+        final String vendor = doPrivileged((PrivilegedAction<String>)() -> System.getProperty("java.vendor"));
+        isJDK = (vendor != null) && vendor.startsWith("Azul ") ? MethodDatabase::isAzulJDK : MethodDatabase::isBaseJDK;
+    }
 
     private final WeakReference<ClassLoader> clRef;
     private final SuspendableClassifier classifier;
@@ -537,6 +544,10 @@ public final class MethodDatabase {
     }
 
     public static boolean isJDK(String className) {
+        return isJDK.test(className);
+    }
+
+    private static boolean isBaseJDK(String className) {
         return className.startsWith("java/")
                || isJavaxInternal(className)
                || className.startsWith("sun/")
@@ -560,6 +571,10 @@ public final class MethodDatabase {
         }
         final String classSubName = className.substring("org/".length());
         return JDK_ORG_PACKAGES.stream().anyMatch(classSubName::startsWith);
+    }
+
+    private static boolean isAzulJDK(String className) {
+        return isBaseJDK(className) || className.startsWith("com/azul/");
     }
 
     public static boolean isProblematicClass(String className) {

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarInstrumentor.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarInstrumentor.java
@@ -100,9 +100,8 @@ public final class QuasarInstrumentor {
     }
 
     boolean shouldInstrument(ClassLoader loader) {
-        return loader != null
-            && !isExcludedClassLoader(loader.getClass().getName())
-            && !isExcludedClassLoader(loader);
+        return (loader == null) ||
+            (!isExcludedClassLoader(loader.getClass().getName()) && !isExcludedClassLoader(loader));
     }
 
     boolean shouldInstrument(String className) {

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/JavaPlatformTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/JavaPlatformTest.java
@@ -79,7 +79,6 @@ public class JavaPlatformTest {
     }
 
     private static boolean isJDKClass(String className) {
-        // The Azul JDK contains some extra "platform" modules, so allow these.
-        return MethodDatabase.isJDK(classToSlashed(className)) || className.startsWith("com.azul.");
+        return MethodDatabase.isJDK(classToSlashed(className));
     }
 }


### PR DESCRIPTION
The platform classloader cannot access classes belonging to the application classloader, which is where Quasar's own classes live. This means that Quasar cannot determine the "common superclass" for any Quasar classes injected into platform byte-code, and specifically for `SuspendExecution` and `RuntimeSuspendExecution` exception classes.

However, the root cause of this problem is that the Azul JDK has added some custom `com.azul.*` modules into the Java platform, but Quasar does not recognise them as belonging to the JDK. Quasar is therefore trying  - **and failing** - to make these new "platform" methods suspendable. Most likely, Quasar should not be attempting to do this in the first place!

A Java instrumentation agent isn't a good place to perform a detailed introspection of a JVM's built-in packages, so reading the `java.vendor` system property and tweaking the `MethodDatabase.isJDK()` function for Azul will have to do :disappointed:.

For reference: `java.vendor` is "Azul Systems, Inc." for this case.