### PR TITLE
CORE-5938: Fix selection logic for which classloaders to instrument.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarInstrumentor.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarInstrumentor.java
@@ -87,7 +87,7 @@ public final class QuasarInstrumentor {
 
     @SuppressWarnings("WeakerAccess")
     public boolean shouldInstrument(ClassLoader loader) {
-        return loader != null && !isExcludedClassLoader(loader.getClass().getName());
+        return loader == null || !isExcludedClassLoader(loader.getClass().getName());
     }
 
     @SuppressWarnings("WeakerAccess")


### PR DESCRIPTION
Quasar is allowed to instrument classes from the bootstrap classloader, so this `null` check is wrong. Fortunately, we will already have substituted `null` for the extension classloader before arriving here, so this fix is only for "correctness".