### PR TITLE
CORE-5938: Initialise MethodDatabase before registering the ClassFileTransformer.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,11 @@ subprojects {
     java {
         toolchain {
             languageVersion = of(11)
+
+            // Configure Gradle to use IBM J9 JDK toolchain.
+            // (You will need to install J9 manually first.)
+            //vendor = JvmVendorSpec.IBM
+            //implementation = JvmImplementation.J9
         }
         withSourcesJar()
         withJavadocJar()

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
@@ -221,11 +221,11 @@ public class JavaAgent {
         // CORDA-3666: Access Classes now so we don't deadlock while
         // loading it later.
         //
-        // We are calling isYieldMethod for the side effect of the JVM
-        // running Classes.<clinit>. We expect this call to return
-        // true.
-        // Prints "Classes ready: true"
-        instrumentor.log(LogLevel.DEBUG, "Classes ready: %s", Classes.isYieldMethod(Classes.FIBER_CLASS_NAME, "park"));
+        // We are calling isJDK(THROWABLE_NAME) for the side effect of the JVM
+        // running both MethodDatabase.<clinit> and Classes.<clinit>. We expect
+        // this call to return true.
+        // Prints "MethodDatabase, Classes ready: true"
+        instrumentor.log(LogLevel.DEBUG, "MethodDatabase, Classes ready: %s", MethodDatabase.isJDK(Classes.THROWABLE_NAME));
 
         Retransform.instrumentation = instrumentation;
         Retransform.instrumentor = instrumentor;

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
@@ -49,9 +49,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.lang.ref.WeakReference;
+import java.net.URI;
 import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.PrivilegedAction;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -60,12 +65,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.function.Predicate;
 
 import static co.paralleluniverse.fibers.instrument.Classes.isYieldMethod;
 import static java.security.AccessController.doPrivileged;
+import static java.util.Collections.unmodifiableMap;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 
 /**
  * <p>
@@ -89,7 +96,7 @@ public final class MethodDatabase {
         "sql/", "swing/",
         "tools/", "transaction/xa/",
         "xml/"
-   );
+    );
     private static final List<String> JDK_ORG_PACKAGES = List.of(
         "w3c/dom/",
         "xml/sax/",
@@ -97,10 +104,33 @@ public final class MethodDatabase {
         "ietf/jgss/"
     );
 
-    private static final Predicate<String> isJDK;
+    private static final String JRT_MODULES = "modules";
+    private static final String JRT_FS = "jrt:/";
+
+    private static final Set<String> JDK_CUSTOM_PACKAGES;
     static {
-        final String vendor = doPrivileged((PrivilegedAction<String>)() -> System.getProperty("java.vendor"));
-        isJDK = (vendor != null) && vendor.startsWith("Azul ") ? MethodDatabase::isAzulJDK : MethodDatabase::isBaseJDK;
+        final FileSystem jrt = FileSystems.getFileSystem(URI.create(JRT_FS));
+        try {
+            // We MUST initialise this BEFORE we install our ClassFileTransformer.
+            // Identify all modules belonging to the JDK installation itself.
+            // This is a subset of the modules inside ModuleLayer.boot().
+            JDK_CUSTOM_PACKAGES = Files.walk(jrt.getPath(JRT_MODULES))
+                .filter(p -> p.getNameCount() == 2)
+                .map(MethodDatabase::findModule)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .flatMap(m -> m.getPackages().stream())
+                .map(p -> p.replace('.', '/') + '/')
+                .filter(p -> !isBaseJDK(p))
+                .collect(toUnmodifiableSet());
+        } catch (IOException e) {
+            throw new InternalError(e.getMessage(), e);
+        }
+    }
+
+    private static Optional<Module> findModule(Path p) {
+        final String moduleName = p.getName(1).toString();
+        return ModuleLayer.boot().findModule(moduleName);
     }
 
     private final WeakReference<ClassLoader> clRef;
@@ -332,7 +362,7 @@ public final class MethodDatabase {
                     map.put(entry.getKey(), entry.getValue());
                 }
             }
-            return Collections.unmodifiableMap(map);
+            return unmodifiableMap(map);
         }
     }
 
@@ -544,7 +574,7 @@ public final class MethodDatabase {
     }
 
     public static boolean isJDK(String className) {
-        return isJDK.test(className);
+        return isBaseJDK(className) || (!JDK_CUSTOM_PACKAGES.isEmpty() && hasAnyPrefix(className, JDK_CUSTOM_PACKAGES));
     }
 
     private static boolean isBaseJDK(String className) {
@@ -562,7 +592,7 @@ public final class MethodDatabase {
             return false;
         }
         final String classSubName = className.substring("javax/".length());
-        return JDK_JAVAX_PACKAGES.stream().anyMatch(classSubName::startsWith);
+        return hasAnyPrefix(classSubName, JDK_JAVAX_PACKAGES);
     }
 
     private static boolean isOrgInternal(String className) {
@@ -570,11 +600,11 @@ public final class MethodDatabase {
             return false;
         }
         final String classSubName = className.substring("org/".length());
-        return JDK_ORG_PACKAGES.stream().anyMatch(classSubName::startsWith);
+        return hasAnyPrefix(classSubName, JDK_ORG_PACKAGES);
     }
 
-    private static boolean isAzulJDK(String className) {
-        return isBaseJDK(className) || className.startsWith("com/azul/");
+    private static boolean hasAnyPrefix(String className, Collection<String> prefixes) {
+        return prefixes.stream().anyMatch(className::startsWith);
     }
 
     public static boolean isProblematicClass(String className) {

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/JavaPlatformTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/JavaPlatformTest.java
@@ -12,10 +12,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 
 import static co.paralleluniverse.common.resource.ClassLoaderUtil.classToSlashed;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
@@ -33,7 +33,7 @@ public class JavaPlatformTest {
             .filter(p -> p.endsWith(".class"))
             .map(p -> p.substring(0, p.length() - ".class".length()))
             .filter(p -> !"module-info".equals(p))
-            .collect(Collectors.toUnmodifiableSet());
+            .collect(toUnmodifiableSet());
 
         // Check that we correctly identify these classes as belonging to the JDK.
         assertThat(classNames)


### PR DESCRIPTION
Ensure the `MethodDatabase.isJDK()` method is fully initialised before registering our `ClassFileTransformer` with the JVM. Not only does this fix a race condition, but it also allows us to query the `jrt:/` filesystem to learn the names of all the JVM's platform packages. This is more precise than querying the `java.vendor` system property, and is particularly useful for IBM's J9 JDK which has _many_ more platform extensions than Azul's JDK.