### PR TITLE
CORE-7641: Upgrade to support Kotlin 1.7.20.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 quasarVersion=0.8.9_r3-SNAPSHOT
-kotlinVersion=1.7.10
+kotlinVersion=1.7.20
 taskTreeVersion=1.3.1
 shadowVersion=6.1.0
 artifactoryVersion=4.21.0
@@ -9,7 +9,7 @@ modulepluginVersion=1.8.12
 
 kotlin.stdlib.default.dependency=false
 
-asmVersion=9.3
+asmVersion=9.4
 
 felixVersion=7.0.5
 felixConfigAdminVersion=1.9.24

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
@@ -57,7 +57,7 @@ final class Classes {
     static final String STACK_OPS_NAME                 = "co/paralleluniverse/fibers/suspend/StackOps";
 
     static final String LAMBDA_METHOD_PREFIX           = "lambda$";
-    static final String KOTLIN_LAMBDA_SUFFIX           = "$lambda-";
+    static final String KOTLIN_LAMBDA_SUFFIX           = "\\$lambda[-$]";
 
     static final String DONT_INSTRUMENT_DESC = Type.getDescriptor(DontInstrument.class);
     static final String INSTRUMENTED_DESC    = Type.getDescriptor(Instrumented.class);

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/DefaultSuspendableClassifier.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/DefaultSuspendableClassifier.java
@@ -16,6 +16,7 @@ package co.paralleluniverse.fibers.instrument;
 import co.paralleluniverse.fibers.instrument.MethodDatabase.SuspendableType;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.regex.Pattern;
 import java.util.stream.StreamSupport;
 
 import static co.paralleluniverse.fibers.instrument.Classes.KOTLIN_LAMBDA_SUFFIX;
@@ -28,6 +29,7 @@ import static java.util.stream.Collectors.toUnmodifiableList;
  * @author pron
  */
 public class DefaultSuspendableClassifier implements SuspendableClassifier {
+    private static final Pattern KOTLIN_LAMBDA = Pattern.compile(KOTLIN_LAMBDA_SUFFIX);
     private final List<SuspendableClassifier> classifiers;
     private final SuspendableClassifier simpleClassifier;
 
@@ -59,7 +61,7 @@ public class DefaultSuspendableClassifier implements SuspendableClassifier {
                 return SuspendableType.SUSPENDABLE;
 
             // lambda$ or $lambda-x
-            if (methodName.startsWith(LAMBDA_METHOD_PREFIX) || methodName.contains(KOTLIN_LAMBDA_SUFFIX)) {
+            if (methodName.startsWith(LAMBDA_METHOD_PREFIX) || KOTLIN_LAMBDA.matcher(methodName).find()) {
                 return SuspendableType.SUSPENDABLE;
             }
         } catch (Exception e) {


### PR DESCRIPTION
The internal names of Kotlin's synthetic lambda methods have different formats between Kotlin 1.7.10 and Kotlin 1.7.20. We need to support both formats.

Upgrading to ASM 9.4 also prevents Quasar from exploding should it ever encounter Java 20 byte-code. It doesn't mean that Quasar _supports_ Java 20 though.