### PR TITLE
NOTICK: Test against Kotlin 1.7.21.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 quasarVersion=0.8.9_r3-SNAPSHOT
-kotlinVersion=1.7.20
+kotlinVersion=1.7.21
 taskTreeVersion=1.3.1
 shadowVersion=6.1.0
 artifactoryVersion=4.21.0


### PR DESCRIPTION
Quasar's instrumentor doesn't actually use Kotlin, although some of the tests use Kotlin code.