### PR TITLE
NOTICK: Eliminate duplicate globs for ignoring packages.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ taskTreeVersion=1.3.1
 shadowVersion=6.1.0
 artifactoryVersion=4.21.0
 assertjVersion=3.22.0
-bndVersion=6.3.1
+bndVersion=6.4.0
 modulepluginVersion=1.8.12
 
 kotlin.stdlib.default.dependency=false

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarInstrumentor.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarInstrumentor.java
@@ -33,7 +33,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiPredicate;
@@ -79,8 +81,8 @@ public final class QuasarInstrumentor {
     private boolean check;
     private boolean allowMonitors;
     private boolean allowBlocking;
-    private final Collection<Pattern> exclusions = ConcurrentHashMap.newKeySet();
-    private final Collection<Pattern> excludedClassLoaders = new ArrayList<>();
+    private final Set<QuasarPattern> exclusions = ConcurrentHashMap.newKeySet();
+    private final Set<QuasarPattern> excludedClassLoaders = new LinkedHashSet<>();
     private final Collection<Pattern> excludedBundleLocations = new ArrayList<>();
     private final Collection<Pattern> cachedBundleLocations = new ArrayList<>();
     private final ByteCodeCache byteCodeCache;
@@ -311,9 +313,10 @@ public final class QuasarInstrumentor {
                 return false;
             final String packageName = className.substring(0, i);
 
-            for (Pattern p : exclusions) {
-                if (p.matcher(packageName).matches())
+            for (QuasarPattern p : exclusions) {
+                if (p.matcher(packageName).matches()) {
                     return true;
+                }
             }
         }
         return false;
@@ -321,7 +324,7 @@ public final class QuasarInstrumentor {
 
     boolean isExcludedClassLoader(String classLoaderName) {
         synchronized(excludedClassLoaders) {
-            for (Pattern pattern : excludedClassLoaders) {
+            for (QuasarPattern pattern : excludedClassLoaders) {
                 if (pattern.matcher(classLoaderName).matches()) {
                     return true;
                 }
@@ -332,7 +335,9 @@ public final class QuasarInstrumentor {
 
     void addExcludedClassLoader(String glob) {
         synchronized(excludedClassLoaders) {
-            excludedClassLoaders.add(classLoaderPattern(glob));
+            if (excludedClassLoaders.add(classLoaderPattern(glob))) {
+                log(INFO, "Ignoring classloaders: %s", glob);
+            }
         }
     }
 
@@ -391,7 +396,7 @@ public final class QuasarInstrumentor {
             : emptyList();
     }
 
-    private static Pattern classLoaderPattern(String glob) {
+    private static QuasarPattern classLoaderPattern(String glob) {
         final StringBuilder out = new StringBuilder(glob.length() + 5).append('^');
         int i = 0;
         while (i < glob.length()) {
@@ -424,7 +429,7 @@ public final class QuasarInstrumentor {
             ++i;
         }
         out.append('$');
-        return Pattern.compile(out.toString());
+        return QuasarPattern.compile(out.toString());
     }
 
     private static Pattern bundleLocationPattern(String glob) {
@@ -491,7 +496,7 @@ public final class QuasarInstrumentor {
         }
     }
 
-    private static Pattern packagePattern(String packageGlob) {
+    private static QuasarPattern packagePattern(String packageGlob) {
         final String glob = packageGlob.replace('.', '/');
         
         final StringBuilder out = new StringBuilder(glob.length() + 5).append('^');
@@ -519,7 +524,7 @@ public final class QuasarInstrumentor {
         
         out.append('$');
         
-        return Pattern.compile(out.toString());
+        return QuasarPattern.compile(out.toString());
     }
 
     public synchronized void addTypeDesc(String id, Iterable<String> descriptors) {

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarPattern.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarPattern.java
@@ -1,0 +1,50 @@
+package co.paralleluniverse.fibers.instrument;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A wrapper around {@link Pattern} that defines equality and comparability
+ * based on that {@link Pattern}'s underlying regular expression.
+ */
+final class QuasarPattern implements Comparable<QuasarPattern> {
+    private final Pattern pattern;
+
+    static QuasarPattern compile(String regex) {
+        return new QuasarPattern(Pattern.compile(regex));
+    }
+
+    private QuasarPattern(Pattern p) {
+        pattern = p;
+    }
+
+    Matcher matcher(String input) {
+        return pattern.matcher(input);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        } else if (!(obj instanceof QuasarPattern)) {
+            return false;
+        }
+        final QuasarPattern other = (QuasarPattern) obj;
+        return pattern.pattern().equals(other.pattern.pattern());
+    }
+
+    @Override
+    public int hashCode() {
+        return pattern.pattern().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return pattern.toString();
+    }
+
+    @Override
+    public int compareTo(QuasarPattern other) {
+        return pattern.pattern().compareTo(other.pattern.pattern());
+    }
+}


### PR DESCRIPTION
Java's `Pattern` class uses "object identity" for `equals` and `hashCode`, so wrap it inside `QuasarPattern` so that all of our final patterns are unique.