### PR TITLE
CORE-10115: Rewrite BundleTracker to ensure uninstalled Bundles are released.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarActivator.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarActivator.java
@@ -2,7 +2,6 @@ package co.paralleluniverse.fibers.instrument;
 
 import org.osgi.annotation.bundle.Capability;
 import org.osgi.annotation.bundle.Header;
-import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -18,10 +17,7 @@ import java.util.logging.Logger;
 import static co.paralleluniverse.fibers.instrument.QuasarInstrumentor.isEmptyOrTrue;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.logging.Level.SEVERE;
-import static org.osgi.framework.Bundle.ACTIVE;
 import static org.osgi.framework.Bundle.INSTALLED;
-import static org.osgi.framework.Bundle.RESOLVED;
-import static org.osgi.framework.Bundle.STARTING;
 import static org.osgi.framework.Constants.EFFECTIVE_ACTIVE;
 import static org.osgi.framework.Constants.EXTENSION_BUNDLE_ACTIVATOR;
 import static org.osgi.framework.Constants.EXTENSION_DIRECTIVE;
@@ -107,13 +103,8 @@ public final class QuasarActivator implements BundleActivator {
         weaver = context.registerService(WeavingHook.class, weavingHook, serviceProperties);
 
         final QuasarBundleTracker quasarTracker = new QuasarBundleTracker(instrumentor);
-        bundleTracker = new BundleTracker<>(context, INSTALLED | RESOLVED | STARTING | ACTIVE, quasarTracker);
+        bundleTracker = new BundleTracker<>(context, INSTALLED, quasarTracker);
         bundleTracker.open();
-
-        // Register the bundles that have already been added to the framework.
-        for (Bundle bundle: context.getBundles()) {
-            quasarTracker.addingBundle(bundle, null);
-        }
 
         if (isEmptyOrTrue(context.getProperty(SERVICE_PROPERTY_NAME))) {
             // Available for testing.

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarBundleTracker.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarBundleTracker.java
@@ -6,8 +6,6 @@ import org.osgi.util.tracker.BundleTrackerCustomizer;
 
 import java.security.AccessControlContext;
 import java.security.AccessControlException;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static co.paralleluniverse.fibers.instrument.LogLevel.WARNING;
 import static co.paralleluniverse.fibers.instrument.QuasarPermission.CONFIGURATION;
@@ -16,16 +14,20 @@ final class QuasarBundleTracker implements BundleTrackerCustomizer<Object> {
     private static final QuasarPermission QUASAR_CONFIG = new QuasarPermission(CONFIGURATION);
 
     private final QuasarInstrumentor instrumentor;
-    private final Set<Bundle> bundles;
 
     QuasarBundleTracker(QuasarInstrumentor instrumentor) {
         this.instrumentor = instrumentor;
-        this.bundles = ConcurrentHashMap.newKeySet();
+    }
+
+    // We are only concerned when the bundle is actually installed, and not
+    // when the bundle returns to the "INSTALLED" state once it has stopped.
+    private static boolean isInstalled(BundleEvent bundleEvent) {
+        return bundleEvent == null || bundleEvent.getType() == BundleEvent.INSTALLED;
     }
 
     @Override
     public Object addingBundle(Bundle bundle, BundleEvent bundleEvent) {
-        if (bundles.add(bundle) && !instrumentor.isExcludedBundleLocation(bundle.getLocation())) {
+        if (isInstalled(bundleEvent) && !instrumentor.isExcludedBundleLocation(bundle.getLocation())) {
             final String ignoredPackages = bundle.getHeaders().get("Quasar-Ignore-Package");
             if (ignoredPackages != null) {
                 try {
@@ -46,12 +48,9 @@ final class QuasarBundleTracker implements BundleTrackerCustomizer<Object> {
 
     @Override
     public void modifiedBundle(Bundle bundle, BundleEvent bundleEvent, Object obj) {
-        removedBundle(bundle, bundleEvent, obj);
-        addingBundle(bundle, bundleEvent);
     }
 
     @Override
     public void removedBundle(Bundle bundle, BundleEvent bundleEvent, Object obj) {
-        bundles.remove(bundle);
     }
 }


### PR DESCRIPTION
We don't _literally_ need to "track" every bundle in the system here. We just need a reliable notification whenever any bundle is installed so that we can parse its headers.