### PR TITLE
NOTICK: use common Docker image for building

### DIFF
--- a/.ci/dev/Dockerfile
+++ b/.ci/dev/Dockerfile
@@ -1,7 +1,0 @@
-FROM azul/zulu-openjdk:11
-RUN apt-get update
-ARG USER="tester"
-ARG UID=999
-ARG GID=999
-RUN groupadd -g ${GID} -o ${USER}
-RUN useradd -o -m -u ${UID} -g ${GID} ${USER}

--- a/.ci/dev/Jenkinsfile
+++ b/.ci/dev/Jenkinsfile
@@ -8,10 +8,15 @@ boolean isRelease = (env.TAG_NAME =~ /^release-.*/)
 
 pipeline {
   agent {
-    dockerfile {
-      label 'standard'
-      additionalBuildArgs "--build-arg USER=\$(id -un) --build-arg UID=\$(id -u) --build-arg GID=\$(id -g)"
-      filename '.ci/dev/Dockerfile'
+    docker {
+        // Our custom docker image
+        image "build-zulu-openjdk:11"
+        label "standard"
+        registryUrl 'https://engineering-docker.software.r3.com/'
+        registryCredentialsId 'artifactory-credentials'
+        // Used to mount storage from the host as a volume to persist the cache between builds
+        args '-v /tmp:/host_tmp'
+        alwaysPull true
     }
   }
 
@@ -29,9 +34,17 @@ pipeline {
     CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
     CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
     CORDA_ARTIFACTORY_REPOKEY = "${isRelease ? 'corda-dependencies' : 'corda-dependencies-dev'}"
+    GRADLE_USER_HOME = "/host_tmp/gradle"
   }
 
   stages {
+    stage('Prep') {
+        steps {
+            // Ensure the dir exists in the mount from the host
+            sh 'mkdir -p ${GRADLE_USER_HOME}'
+        }
+    }
+
     stage('Compile') {
       steps {
         sh "./gradlew --no-daemon -Pcompilation.allWarningsAsErrors=true -Ptests.failFast=false -Ptests.ignoreFailures=true clean assemble"


### PR DESCRIPTION
* drop building Jenkins agent Docker image each time
* use common R3 Java 11 Docker image
* mount a folder from host to persist files downloaded by Gradle