### PR TITLE
NOTICK: Upgrade testing dependencies.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 quasarVersion=0.8.10_r3-SNAPSHOT
-kotlinVersion=1.7.21
+kotlinVersion=1.8.10
 taskTreeVersion=1.3.1
 shadowVersion=6.1.0
 artifactoryVersion=4.21.0
@@ -12,17 +12,17 @@ kotlin.stdlib.default.dependency=false
 asmVersion=9.4
 
 felixVersion=7.0.5
-felixConfigAdminVersion=1.9.24
+felixConfigAdminVersion=1.9.26
 felixLogVersion=1.2.6
-felixScrVersion=2.2.2
+felixScrVersion=2.2.6
 felixSecurityVersion=2.8.3
 
-junitJupiterVersion=5.9.0
-junitPlatformVersion=1.9.0
+junitJupiterVersion=5.9.2
+junitPlatformVersion=1.9.2
 osgiServiceComponentVersion=1.5.0
-osgiTestJunit5Version=1.1.0
-osgiUtilFunctionVersion=1.1.0
-osgiUtilPromiseVersion=1.2.0
+osgiTestJunit5Version=1.2.1
+osgiUtilFunctionVersion=1.2.0
+osgiUtilPromiseVersion=1.3.0
 testngVersion=7.6.1
 
 artifactoryContextUrl=https://software.r3.com/artifactory

--- a/quasar-kotlin/build.gradle
+++ b/quasar-kotlin/build.gradle
@@ -1,3 +1,6 @@
+import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8
+
 plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'org.javamodularity.moduleplugin'
@@ -58,10 +61,10 @@ tasks.named('check') {
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        jvmTarget = '11'
-        apiVersion = '1.7'
-        languageVersion = '1.7'
+    compilerOptions {
+        jvmTarget = JVM_11
+        apiVersion = KOTLIN_1_8
+        languageVersion = KOTLIN_1_8
         allWarningsAsErrors = true
         // We need to enable this, but must watch for compiler warnings about
         // abstract methods in the base class not having an implementation!


### PR DESCRIPTION
- Kotlin 1.7.21 -> 1.8.10
- JUnit 5.9.0 -> 5.9.2
- Assorted OSGi dependencies.