### PR TITLE
CORE-11206: Add KotlinClassifier to the Quasar agent and framework extension.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ subprojects {
         }
     }
 
-    configurations.all {
+    configurations.configureEach {
         resolutionStrategy {
             dependencySubstitution {
                 // Kryo demands Objenesis 2.5.1, but Mockito wants Objenesis 2.6
@@ -319,17 +319,19 @@ logger.lifecycle("Building quasar version: {}", quasarVersion)
 def scanAndInstrument(SourceSet sset, configs) {
 
     def cp = sset.output.classesDirs.getAsPath() + ':' + sset.output.resourcesDir + ':' + configs*.asPath.join(':')
+    def suspendableSupersFile = "${sset.output.dirs.singleFile}/META-INF/suspendable-supers"
 
     // ENT-5598 quasar-kotlin has two output directories, java and kotlin.
     // So we have to cope with multiple directories in classesDirs.
 
+    ant.delete(file: suspendableSupersFile)
     ant.taskdef(
             name:'scanSuspendables',
             classname:'co.paralleluniverse.fibers.instrument.SuspendablesScanner',
             classpath: cp)
     ant.scanSuspendables(
             auto: false,
-            supersFile:"${sset.output.dirs.singleFile}/META-INF/suspendable-supers",
+            supersFile: suspendableSupersFile,
             append: true) {
         for (File f : sset.output.classesDirs) {
             fileset(dir: f)
@@ -340,10 +342,10 @@ def scanAndInstrument(SourceSet sset, configs) {
             name:'instrumentation',
             classname:'co.paralleluniverse.fibers.instrument.InstrumentationTask',
             classpath: cp)
-    ant.instrumentation(verbose:'true', check:'true', debug:'true') {
+    ant.instrumentation(verbose: true, check: true, debug: true) {
         for (File f : sset.output.classesDirs) {
             fileset(dir: f) {
-                exclude(name: 'co/paralleluniverse/fibers/instrument/*.class')
+                exclude(name: 'co/paralleluniverse/fibers/instrument/**/*.class')
             }
         }
     }
@@ -619,7 +621,6 @@ project (':quasar-core') {
     def coreBundle = tasks.register('coreBundle', Bundle) {
         dependsOn classicJar
         from(zipTree(classicJar.flatMap { it.archiveFile })) {
-            exclude 'META-INF/suspendable*'
             exclude 'co/paralleluniverse/asm/**'
             exclude 'co/paralleluniverse/common/asm/**'
             exclude 'co/paralleluniverse/common/resource/**'
@@ -665,7 +666,7 @@ Import-Package: \
     def agentBundle = tasks.register('agentBundle', Bundle) {
         dependsOn shadowJar
         from(shadowFiles) {
-            include 'META-INF/suspendable*'
+            exclude 'META-INF/suspendable*'
             include 'co/paralleluniverse/asm/**'
             include 'co/paralleluniverse/common/asm/**'
             include 'co/paralleluniverse/common/resource/**'
@@ -723,7 +724,7 @@ Import-Package: !org.osgi.framework.*,*
     def frameworkExtensionBundle = tasks.register('frameworkExtensionBundle', Bundle) {
         dependsOn shadowJar
         from(shadowFiles) {
-            include 'META-INF/suspendable*'
+            exclude 'META-INF/suspendable*'
             include 'co/paralleluniverse/asm/**'
             include 'co/paralleluniverse/common/asm/**'
             include 'co/paralleluniverse/common/resource/**'

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/CheckInstrumentationVisitor.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/CheckInstrumentationVisitor.java
@@ -147,7 +147,7 @@ class CheckInstrumentationVisitor extends ClassVisitor {
 
         if (suspendable == null) {
             // look for @Suspendable annotation
-            return new MethodVisitor(ASMAPI) {
+            return new MethodVisitor(api) {
                 private boolean susp = false;
 
                 @Override

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
@@ -57,7 +57,6 @@ final class Classes {
     static final String STACK_OPS_NAME                 = "co/paralleluniverse/fibers/suspend/StackOps";
 
     static final String LAMBDA_METHOD_PREFIX           = "lambda$";
-    static final String KOTLIN_LAMBDA_SUFFIX           = "\\$lambda[-$]";
 
     static final String DONT_INSTRUMENT_DESC = Type.getDescriptor(DontInstrument.class);
     static final String INSTRUMENTED_DESC    = Type.getDescriptor(Instrumented.class);

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/DefaultSuspendableClassifier.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/DefaultSuspendableClassifier.java
@@ -14,27 +14,30 @@
 package co.paralleluniverse.fibers.instrument;
 
 import co.paralleluniverse.fibers.instrument.MethodDatabase.SuspendableType;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.regex.Pattern;
-import java.util.stream.StreamSupport;
 
-import static co.paralleluniverse.fibers.instrument.Classes.KOTLIN_LAMBDA_SUFFIX;
 import static co.paralleluniverse.fibers.instrument.Classes.LAMBDA_METHOD_PREFIX;
 import static co.paralleluniverse.fibers.instrument.Classes.SUSPEND_EXECUTION_NAME;
-import static java.util.stream.Collectors.toUnmodifiableList;
+import static java.util.Collections.unmodifiableList;
 
 /**
  *
  * @author pron
  */
-public class DefaultSuspendableClassifier implements SuspendableClassifier {
-    private static final Pattern KOTLIN_LAMBDA = Pattern.compile(KOTLIN_LAMBDA_SUFFIX);
+public final class DefaultSuspendableClassifier implements SuspendableClassifier {
+    private static final SuspendableClassifier KOTLIN_CLASSIFIER = new KotlinClassifier();
     private final List<SuspendableClassifier> classifiers;
     private final SuspendableClassifier simpleClassifier;
 
     public DefaultSuspendableClassifier(ClassLoader classLoader) {
-        this.classifiers = StreamSupport.stream(ServiceLoader.load(SuspendableClassifier.class, classLoader).spliterator(), false).collect(toUnmodifiableList());
+        final List<SuspendableClassifier> localClassifiers = new ArrayList<>();
+        localClassifiers.add(KOTLIN_CLASSIFIER);
+        for (SuspendableClassifier classifier : ServiceLoader.load(SuspendableClassifier.class, classLoader)) {
+            localClassifiers.add(classifier);
+        }
+        this.classifiers = unmodifiableList(localClassifiers);
         this.simpleClassifier = new SimpleSuspendableClassifier(classLoader);
     }
 
@@ -47,21 +50,24 @@ public class DefaultSuspendableClassifier implements SuspendableClassifier {
             // classifier service
             for (SuspendableClassifier sc : classifiers) {
                 st = sc.isSuspendable(db, sourceName, sourceDebugInfo, isInterface, className, superClassName, interfaces, methodName, methodDesc, methodSignature, methodExceptions);
-                if (st != null)
+                if (st != null) {
                     return st;
+                }
             }
 
             // simple classifier (files in META-INF)
             st = simpleClassifier.isSuspendable(db, sourceName, sourceDebugInfo, isInterface, className, superClassName, interfaces, methodName, methodDesc, methodSignature, methodExceptions);
-            if (st != null)
+            if (st != null) {
                 return st;
+            }
 
             // throws SuspendExecution
-            if (checkExceptions(methodExceptions))
+            if (checkExceptions(methodExceptions)) {
                 return SuspendableType.SUSPENDABLE;
+            }
 
-            // lambda$ or $lambda-x
-            if (methodName.startsWith(LAMBDA_METHOD_PREFIX) || KOTLIN_LAMBDA.matcher(methodName).find()) {
+            // lambda$
+            if (methodName.startsWith(LAMBDA_METHOD_PREFIX)) {
                 return SuspendableType.SUSPENDABLE;
             }
         } catch (Exception e) {
@@ -74,8 +80,9 @@ public class DefaultSuspendableClassifier implements SuspendableClassifier {
     private static boolean checkExceptions(String[] exceptions) {
         if (exceptions != null) {
             for (String ex : exceptions) {
-                if (ex.equals(SUSPEND_EXECUTION_NAME))
+                if (ex.equals(SUSPEND_EXECUTION_NAME)) {
                     return true;
+                }
             }
         }
         return false;

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/InstrumentClass.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/InstrumentClass.java
@@ -147,21 +147,24 @@ class InstrumentClass extends ClassVisitor {
     @Override
     public MethodVisitor visitMethod(final int access, final String name, final String desc, final String signature, final String[] exceptions) {
         SuspendableType markedSuspendable = null;
-        if (suspendableInterface)
+        if (suspendableInterface) {
             markedSuspendable = SuspendableType.SUSPENDABLE_SUPER;
-        if (markedSuspendable == null)
+        }
+        if (markedSuspendable == null) {
             markedSuspendable = classifier.isSuspendable(db, sourceName, sourceDebugInfo, isInterface, className, classEntry.getSuperName(), classEntry.getInterfaces(), name, desc, signature, exceptions);
+        }
         final SuspendableType setSuspendable = classEntry.check(name, desc);
 
-        if (setSuspendable == null)
+        if (setSuspendable == null) {
             classEntry.set(name, desc, markedSuspendable != null ? markedSuspendable : SuspendableType.NON_SUSPENDABLE);
+        }
 
         final SuspendableType suspendable = max(markedSuspendable, setSuspendable, SuspendableType.NON_SUSPENDABLE);
 
         if (checkAccessForMethodVisitor(access) && !isYieldMethod(className, name)) {
             final MethodNode mn = new MethodNode(access, name, desc, signature, exceptions);
 
-            return new MethodVisitor(ASMAPI, mn) {
+            return new MethodVisitor(api, mn) {
                 private SuspendableType susp = suspendable;
                 private boolean committed = false;
 
@@ -203,8 +206,9 @@ class InstrumentClass extends ClassVisitor {
                     }
                     committed = true;
 
-                    if (db.isDebug())
+                    if (db.isDebug()) {
                         db.log(LogLevel.INFO, "Method %s#%s%s suspendable: %s (markedSuspendable: %s setSuspendable: %s)", className, name, desc, susp, susp, setSuspendable);
+                    }
                     classEntry.set(name, desc, susp);
 
                     if (susp == SuspendableType.SUSPENDABLE && checkAccessForMethodInstrumentation(access)) {
@@ -218,7 +222,7 @@ class InstrumentClass extends ClassVisitor {
                     } else {
                         MethodVisitor _mv = makeOutMV(mn);
                         _mv = new JSRInlinerAdapter(_mv, access, name, desc, signature, exceptions);
-                        mn.accept(new MethodVisitor(ASMAPI, _mv) {
+                        mn.accept(new MethodVisitor(api, _mv) {
                             @Override
                             public void visitEnd() {
                                 // don't call visitEnd on MV
@@ -316,9 +320,9 @@ class InstrumentClass extends ClassVisitor {
         return (access & Opcodes.ACC_ABSTRACT) == 0;
     }
 
-    private static SuspendableType max(SuspendableType a, SuspendableType b, SuspendableType def) {
+    private static SuspendableType max(SuspendableType a, SuspendableType b, SuspendableType defaultValue) {
         final SuspendableType res = max(a, b);
-        return res != null ? res : def;
+        return res != null ? res : defaultValue;
     }
 
     private static SuspendableType max(SuspendableType a, SuspendableType b) {

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/KotlinClassifier.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/KotlinClassifier.java
@@ -11,27 +11,26 @@
  * under the terms of the GNU Lesser General Public License version 3.0
  * as published by the Free Software Foundation.
  */
-package co.paralleluniverse.kotlin;
-
-import co.paralleluniverse.fibers.instrument.LogLevel;
-import co.paralleluniverse.fibers.instrument.MethodDatabase;
-import co.paralleluniverse.fibers.instrument.SimpleSuspendableClassifier;
-import co.paralleluniverse.fibers.instrument.SuspendableClassifier;
+package co.paralleluniverse.fibers.instrument;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Quasar-Kotlin M14 integration.
  *
  * @author circlespainter
  */
-public class KotlinClassifier implements SuspendableClassifier {
+final class KotlinClassifier implements SuspendableClassifier {
+    private static final Pattern KOTLIN_LAMBDA_SUFFIX = Pattern.compile("\\$lambda[-$]");
+    private static final String ACCESS_METHOD_PREFIX = "access$";
     private static final String PKG_PREFIX = "kotlin";
     private static final String[][] supers;
     private static final String[] excludePrefixes;
 
     static {
-        final ArrayList<String[]> supersList = new ArrayList<>();
+        final List<String[]> supersList = new ArrayList<>();
 
         // Kotlin properties reflection support
         supersList.add(sa("kotlin/reflect/KCallable", "call", "callBy"));
@@ -63,14 +62,16 @@ public class KotlinClassifier implements SuspendableClassifier {
         supersList.add(sa("kotlin/Lazy", "getValue"));
 
         // Kotlin functions support
-        for (int i = 0; i <= 22; i++)
+        for (int i = 0; i <= 22; ++i) {
             supersList.add(sa("kotlin/jvm/functions/Function" + i, "invoke"));
+        }
+        supersList.add(sa("kotlin/jvm/functions/FunctionN", "invoke"));
 
         // Kotlin M14 doesn't seem to add `@Suspendable` to the generated `run` when passing a `@Suspendable` lambda
         supersList.add(sa("co/paralleluniverse/strands/SuspendableCallable", "run"));
         supersList.add(sa("co/paralleluniverse/strands/SuspendableRunnable", "run"));
 
-        supers = supersList.toArray(new String[0][0]);
+        supers = supersList.toArray(new String[0][]);
 
 
         // Class prefixes that are known not to suspend
@@ -98,7 +99,10 @@ public class KotlinClassifier implements SuspendableClassifier {
                 for (int i = 1; i < s.length; i++) {
                     if (methodName.matches(s[i])) {
                         if (db.isVerbose()) {
-                            db.getLog().log(LogLevel.INFO, KotlinClassifier.class.getName() + ": " + className + "." + methodName + " supersOrEqual " + s[0] + "." + s[i]);
+                            db.getLog().log(LogLevel.INFO,
+                                "%s: %s.%s supersOrEqual %s.%s",
+                                KotlinClassifier.class.getName(), className, methodName, s[0], s[i]
+                            );
                         }
                         return MethodDatabase.SuspendableType.SUSPENDABLE_SUPER;
                     }
@@ -121,17 +125,21 @@ public class KotlinClassifier implements SuspendableClassifier {
 
         for (final String[] s : supers) {
             if (SimpleSuspendableClassifier.extendsOrImplements(s[0], db, superClassName, interfaces))
-                for (int i = 1; i < s.length; i++) {
+                for (int i = 1; i < s.length; ++i) {
                     if (methodName.matches(s[i])) {
-                        if (db.isVerbose())
-                            db.getLog().log(LogLevel.INFO, KotlinClassifier.class.getName() + ": " + className + "." + methodName + " extends " + s[0] + "." + s[i]);
+                        if (db.isVerbose()) {
+                            db.getLog().log(LogLevel.INFO,
+                                "%s: %s.%s extends %s.%s",
+                                KotlinClassifier.class.getName(), className, methodName, s[0], s[i]
+                            );
+                        }
                         return MethodDatabase.SuspendableType.SUSPENDABLE;
                     }
                 }
         }
 
         // Java7 compilation scheme
-        if (methodName.startsWith("access$") || methodName.contains("$lambda-")) {
+        if (methodName.startsWith(ACCESS_METHOD_PREFIX) || KOTLIN_LAMBDA_SUFFIX.matcher(methodName).find()) {
             return MethodDatabase.SuspendableType.SUSPENDABLE;
         }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/LabelSuspendableCallSitesClassVisitor.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/LabelSuspendableCallSitesClassVisitor.java
@@ -49,7 +49,7 @@ class LabelSuspendableCallSitesClassVisitor extends ClassVisitor {
             // Analyze, fill and enqueue method ASTs
             final MethodVisitor outMV = super.visitMethod(access, name, desc, signature, exceptions);
 
-            return new MethodVisitor(ASMAPI, outMV) {
+            return new MethodVisitor(api, outMV) {
                 private int currLineNumber = -1;
 
                 @Override

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SimpleSuspendableClassifier.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SimpleSuspendableClassifier.java
@@ -18,7 +18,6 @@ import co.paralleluniverse.fibers.instrument.MethodDatabase.SuspendableType;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -31,12 +30,13 @@ import java.util.Set;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.security.AccessController.doPrivileged;
+import static java.util.Collections.unmodifiableSet;
 
 /**
  *
  * @author pron
  */
-public class SimpleSuspendableClassifier implements SuspendableClassifier {
+final class SimpleSuspendableClassifier implements SuspendableClassifier {
     private static final String PREFIX = "META-INF/";
     private static final String SUSPENDABLES_FILE = "suspendables";
     private static final String SUSPENDABLE_SUPERS_FILE = "suspendable-supers";
@@ -46,17 +46,9 @@ public class SimpleSuspendableClassifier implements SuspendableClassifier {
     private final Set<String> suspendableSupers = new HashSet<>();
     private final Set<String> suspendableSuperInterfaces = new HashSet<>();
 
-    public SimpleSuspendableClassifier(ClassLoader classLoader) {
+    SimpleSuspendableClassifier(ClassLoader classLoader) {
         readFiles(classLoader, SUSPENDABLES_FILE, suspendables, suspendableClasses);
         readFiles(classLoader, SUSPENDABLE_SUPERS_FILE, suspendableSupers, suspendableSuperInterfaces);
-    }
-
-    // Allows loading and querying custom 'suspendables' and 'suspendable-supers' resources
-    public SimpleSuspendableClassifier(final ClassLoader classLoader, final String[] suspendablesResources, final String[] suspendableSupersResources) {
-        for (final String sus : suspendablesResources)
-            readFiles(classLoader, sus, suspendables, suspendableClasses);
-        for (final String sus : suspendableSupersResources)
-            readFiles(classLoader, sus, suspendableSupers, suspendableSuperInterfaces);
     }
 
     SimpleSuspendableClassifier(String suspendablesFileName) {
@@ -64,11 +56,11 @@ public class SimpleSuspendableClassifier implements SuspendableClassifier {
     }
 
     Set<String> getSuspendables() {
-        return suspendables;
+        return unmodifiableSet(suspendables);
     }
 
     Set<String> getSuspendableClasses() {
-        return suspendableClasses;
+        return unmodifiableSet(suspendableClasses);
     }
 
     private static Enumeration<URL> getFiles(ClassLoader classLoader, String fileName) {
@@ -99,16 +91,14 @@ public class SimpleSuspendableClassifier implements SuspendableClassifier {
 
     private static void parse(URL file, Set<String> set, Set<String> classSet) {
         doPrivileged((PrivilegedAction<Void>)() -> {
-            try (InputStream is = file.openStream();
-                 BufferedReader reader = new BufferedReader(new InputStreamReader(is, UTF_8))) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(file.openStream(), UTF_8))) {
                 String line;
 
                 for (int linenum = 1; (line = reader.readLine()) != null; linenum++) {
                     final String s = line.trim();
-                    if (s.isEmpty())
+                    if (s.isEmpty() || s.charAt(0) == '#') {
                         continue;
-                    if (s.charAt(0) == '#')
-                        continue;
+                    }
                     final int index = s.lastIndexOf('.');
                     if (index <= 0) {
                         System.err.println("Can't parse line " + linenum + " in " + file + ": " + line);
@@ -119,10 +109,12 @@ public class SimpleSuspendableClassifier implements SuspendableClassifier {
                     final String fullName = className + '.' + methodName;
 
                     if (methodName.equals("*")) {
-                        if (classSet != null)
+                        if (classSet != null) {
                             classSet.add(className);
-                    } else
+                        }
+                    } else {
                         set.add(fullName);
+                    }
                 }
             } catch (IOException e) {
                 // silently ignore

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SuspOffsetsAfterInstrClassVisitor.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SuspOffsetsAfterInstrClassVisitor.java
@@ -64,7 +64,7 @@ class SuspOffsetsAfterInstrClassVisitor extends ClassVisitor {
             // Analyze, fill and enqueue method ASTs
             final MethodVisitor outMV = super.visitMethod(access, name, desc, signature, exceptions);
 
-            return new MethodVisitor(ASMAPI, outMV) {
+            return new MethodVisitor(api, outMV) {
                 private Label currLabel = null;
                 private int prevOffset = -1;
                 private boolean instrumented;
@@ -80,7 +80,7 @@ class SuspOffsetsAfterInstrClassVisitor extends ClassVisitor {
                     if (INSTRUMENTED_DESC.equals(adesc)) {
                         instrumented = true;
 
-                        return new AnnotationVisitor(ASMAPI) { // Only collect info
+                        return new AnnotationVisitor(api) { // Only collect info
                             @Override
                             public void visit(String attrib, Object value) {
                                 if (null != attrib)
@@ -109,7 +109,7 @@ class SuspOffsetsAfterInstrClassVisitor extends ClassVisitor {
                             public AnnotationVisitor visitArray(String attrib) {
                                 // String[] value not handled by visit
                                 if (Instrumented.FIELD_NAME_SUSPENDABLE_CALL_SITE_NAMES.equals(attrib))
-                                    return new AnnotationVisitor(ASMAPI) {
+                                    return new AnnotationVisitor(api) {
                                         final List<String> callSites = new ArrayList<>();
                                         
                                         @Override

--- a/quasar-kotlin/build.gradle
+++ b/quasar-kotlin/build.gradle
@@ -11,11 +11,13 @@ ext {
     moduleName = 'co.paralleluniverse.quasar.kotlin'
 }
 
-configurations.all {
+configurations.configureEach {
     resolutionStrategy {
         dependencySubstitution {
-            substitute module('org.jetbrains.kotlin:kotlin-stdlib') with module("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
-            substitute module('org.jetbrains.kotlin:kotlin-stdlib-common') with module("org.jetbrains.kotlin:kotlin-stdlib-common:$kotlinVersion")
+            substitute module('org.jetbrains.kotlin:kotlin-stdlib') using module("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
+            substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk7') using module("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
+            substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk8') using module("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
+            substitute module('org.jetbrains.kotlin:kotlin-stdlib-common') using module("org.jetbrains.kotlin:kotlin-stdlib-common:$kotlinVersion")
         }
     }
 }
@@ -26,7 +28,7 @@ dependencies {
         exclude module: 'quasar-core'
     }
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 }
 

--- a/quasar-kotlin/src/main/resources/META-INF/services/co.paralleluniverse.fibers.instrument.SuspendableClassifier
+++ b/quasar-kotlin/src/main/resources/META-INF/services/co.paralleluniverse.fibers.instrument.SuspendableClassifier
@@ -1,1 +1,0 @@
-co.paralleluniverse.kotlin.KotlinClassifier


### PR DESCRIPTION
Refactor Quasar's `KotlinClassifier` from `quasar-kotlin` directly into the instrumentor itself. Also move the `META-INF/suspendable-supers` file out of the instrumentor, and into the ordinary `quasar-core` bundle it is referring to.

I have also added Kotlin's `FunctionN` interface to `KotlinClassifier`, although there may be other interfaces since Kotlin M14(!!) that we may yet need to include too.