### PR TITLE
CORE-11417: Do not instrument dynamic StringConcatFactory invocations.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/InstrumentMethod.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/InstrumentMethod.java
@@ -96,6 +96,12 @@ class InstrumentMethod {
     private static final boolean optimizationDisabled = false; // SystemProperties.isEmptyOrTrue("co.paralleluniverse.fibers.disableInstrumentationOptimization");
     private static final boolean HANDLE_PROXY_INVOCATIONS = true;
 
+    // An invokedynamic instruction will always be instrumented, unless it's for one of these classes.
+    private static final Set<String> DYNAMIC_UNINSTRUMENTED_CLASSES = Set.of(
+        "java/lang/invoke/LambdaMetafactory",
+        "java/lang/invoke/StringConcatFactory"
+    );
+
     // private final boolean verifyInstrumentation; //
     // private static final int PREEMPTION_BACKBRANCH = 0;
     // private static final int PREEMPTION_CALL = 1;
@@ -229,14 +235,18 @@ class InstrumentMethod {
                 && !isInvocationHandlerInvocation(owner, name)) {
                 SuspendableType st = db.isMethodSuspendable(owner, name, desc, opcode);
 
-                if (st == SuspendableType.NON_SUSPENDABLE)
+                if (st == SuspendableType.NON_SUSPENDABLE) {
                     susp = false;
+                }
             }
         } else if (type == AbstractInsnNode.INVOKE_DYNAMIC_INSN) { // invoke dynamic
-            if (owner.equals("java/lang/invoke/LambdaMetafactory")) // lambda
+            if (DYNAMIC_UNINSTRUMENTED_CLASSES.contains(owner)) {
+                // lambda, or string concatenation
                 susp = false;
-        } else
+            }
+        } else {
             susp = false;
+        }
 
         return susp;
     }
@@ -284,12 +294,14 @@ class InstrumentMethod {
                     } else if (in.getType() == AbstractInsnNode.INVOKE_DYNAMIC_INSN) {
                         // invoke dynamic
                         final InvokeDynamicInsnNode idin = (InvokeDynamicInsnNode) in;
-                        if (idin.bsm.getOwner().equals("java/lang/invoke/LambdaMetafactory")) {
-                            // lambda
-                            db.log(LogLevel.DEBUG, "Lambda at instruction %d", i);
+                        final String owner = idin.bsm.getOwner();
+                        if (DYNAMIC_UNINSTRUMENTED_CLASSES.contains(owner)) {
+                            // lambda, or string concatenation
+                            db.log(LogLevel.DEBUG, "%s at instruction %d", owner, i);
                             susp = false;
-                        } else
+                        } else {
                             db.log(LogLevel.DEBUG, "InvokeDynamic Method call at instruction %d is assumed suspendable", i);
+                        }
                     }
 
                     if (susp) {

--- a/quasar-osgi-tests/osgi-super-classes/build.gradle
+++ b/quasar-osgi-tests/osgi-super-classes/build.gradle
@@ -5,5 +5,6 @@ plugins {
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
+    compileOnly project(':quasar-osgi-tests:osgi-annotation')
     api project(':quasar-osgi-tests:osgi-base')
 }

--- a/quasar-osgi-tests/osgi-super-classes/src/main/java/module-info.java
+++ b/quasar-osgi-tests/osgi-super-classes/src/main/java/module-info.java
@@ -1,5 +1,6 @@
 module org.testing.osgi.supers {
     requires static osgi.annotation;
+    requires static org.testing.osgi.annotation;
     requires org.testing.osgi.base;
 
     exports org.testing.osgi.supers;

--- a/quasar-osgi-tests/osgi-super-classes/src/main/java/org/testing/osgi/supers/SuperClassAction.java
+++ b/quasar-osgi-tests/osgi-super-classes/src/main/java/org/testing/osgi/supers/SuperClassAction.java
@@ -1,16 +1,24 @@
 package org.testing.osgi.supers;
 
+import org.testing.osgi.annotation.Suspendable;
+import java.lang.invoke.MethodHandle;
 import java.util.function.Function;
 
 @SuppressWarnings("unused")
-public class SuperClassAction implements Function<String, Exception> {
+public class SuperClassAction implements Function<MethodHandle, Throwable> {
+    @Suspendable
     @Override
-    public Exception apply(String message) {
+    public Throwable apply(MethodHandle message) {
         try {
-            throw new FourthException(message);
+            // Invoking a MethodHandle is always suspendable.
+            throw new FourthException((String) message.invoke());
         } catch (FourthException | RuntimeException e) {
             System.err.println("Caught: " + e.getMessage());
             return e;
+        } catch (Error e) {
+            throw e;
+        } catch (Throwable t) {
+            return t;
         }
     }
 }

--- a/quasar-osgi-tests/src/osgi-test/java/org/testing/osgi/BundleLocatorTest.java
+++ b/quasar-osgi-tests/src/osgi-test/java/org/testing/osgi/BundleLocatorTest.java
@@ -15,6 +15,8 @@ import org.osgi.test.common.annotation.InjectBundleContext;
 import org.osgi.test.common.annotation.InjectService;
 import org.osgi.test.junit5.context.BundleContextExtension;
 import org.osgi.test.junit5.service.ServiceExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testing.osgi.base.BaseException;
 import org.testing.osgi.base.OsgiException;
 import org.testing.osgi.exception.first.FirstException;
@@ -23,6 +25,7 @@ import org.testing.osgi.security.SecurityConfig;
 import org.testing.osgi.unprivileged.Unprivileged;
 
 import java.io.InputStream;
+import java.lang.invoke.MethodHandle;
 import java.util.Collection;
 import java.util.function.Function;
 
@@ -40,6 +43,7 @@ import static org.testing.osgi.security.SecurityConfig.ALL_PERMISSIONS;
 @TestInstance(PER_CLASS)
 class BundleLocatorTest {
     private static final String SUPER_CLASS_ACTION_CLASS_NAME = "org.testing.osgi.supers.SuperClassAction";
+    private static final Logger LOGGER = LoggerFactory.getLogger(BundleLocatorTest.class);
 
     private QuasarInstrumentor instrumentor;
 
@@ -107,8 +111,8 @@ class BundleLocatorTest {
 
     private void assertSuperClassesFor(final Bundle supers) throws Exception {
         @SuppressWarnings("unchecked")
-        final Class<? extends Function<String, Exception>> testClass = Unprivileged.doUnprivileged(() ->
-            (Class<? extends Function<String, Exception>>) supers.loadClass(SUPER_CLASS_ACTION_CLASS_NAME)
+        final Class<? extends Function<MethodHandle, Throwable>> testClass = Unprivileged.doUnprivileged(() ->
+            (Class<? extends Function<MethodHandle, Throwable>>) supers.loadClass(SUPER_CLASS_ACTION_CLASS_NAME)
         );
 
         assertAll("Superclass mapping allocations",
@@ -126,6 +130,7 @@ class BundleLocatorTest {
     }
 
     private void assertClassesBelongToClassLoader(Collection<String> classNames, ClassLoader actual) {
+        LOGGER.info("Checking classes {} for classloader {}", classNames, actual);
         assertFalse(classNames.isEmpty(), "MethodDatabase for " + actual + " should not be empty.");
         assertAll("Mapping for " + actual, classNames.stream().map(className -> {
             final String actualClassName = className.replace('/', '.');


### PR DESCRIPTION
The `java.lang.invoke.StringConcatFactory` class can _never_ suspend, so there is no point instrumenting its call-sites. This should prevent a lot of unnecessary instrumentation for Kotlin 1.5.20+ code, and possibly Java code too.