### PR TITLE
NOTICK Allow choice of ClassResolver for serializing Fibers.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
@@ -38,12 +38,14 @@ import co.paralleluniverse.strands.SuspendableCallable;
 import co.paralleluniverse.strands.SuspendableRunnable;
 import co.paralleluniverse.strands.SuspendableUtils.VoidSuspendableCallable;
 import co.paralleluniverse.strands.dataflow.Val;
+import com.esotericsoftware.kryo.ClassResolver;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Registration;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
+import com.esotericsoftware.kryo.util.DefaultClassResolver;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.io.StringWriter;
@@ -2135,7 +2137,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
     }
 
     /**
-     * Returns a {@link ByteArraySerializer} capable of serializing an object graph containing fibers.
+     * @return a {@link ByteArraySerializer} capable of serializing an object graph containing fibers.
      */
     public static ByteArraySerializer getFiberSerializer() {
         return getFiberSerializer(true);
@@ -2151,15 +2153,30 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
      */
     public static ByteArraySerializer getFiberSerializer(boolean includeThreadLocals) {
         final KryoSerializer s = new KryoSerializer();
-        s.getKryo().addDefaultSerializer(Fiber.class, new FiberSerializer(includeThreadLocals));
-        s.getKryo().addDefaultSerializer(ThreadLocal.class, new ThreadLocalSerializer());
-        s.getKryo().addDefaultSerializer(FiberWriter.class, new FiberWriterSerializer());
-        s.getKryo().addDefaultSerializer(CustomFiberWriter.class, new CustomFiberWriterSerializer());
-        s.getKryo().register(Fiber.class);
-        s.getKryo().register(ThreadLocal.class);
-        s.getKryo().register(InheritableThreadLocal.class);
-        s.getKryo().register(ThreadLocalSerializer.DEFAULT.class);
-        s.getKryo().register(FiberWriter.class);
+        return getFiberSerializer(new DefaultClassResolver(), includeThreadLocals);
+    }
+
+    /**
+     * Returns a {@link ByteArraySerializer} capable of serializing an object graph containing fibers.
+     *
+     * @param classResolver A custom {@link ClassResolver} for Kryo to use. Cannot be {@code null}.
+     * @param includeThreadLocals if true, thread/fiber local storage slots will also be serialised.
+     *                            You may want to set this to false if you are using frameworks that put
+     *                            things that cannot be properly serialised into TLS slots, or if the feature
+     *                            causes other issues.
+     */
+    public static ByteArraySerializer getFiberSerializer(ClassResolver classResolver, boolean includeThreadLocals) {
+        final KryoSerializer s = new KryoSerializer(classResolver);
+        final Kryo kryo = s.getKryo();
+        kryo.addDefaultSerializer(Fiber.class, new FiberSerializer(includeThreadLocals));
+        kryo.addDefaultSerializer(ThreadLocal.class, new ThreadLocalSerializer());
+        kryo.addDefaultSerializer(FiberWriter.class, new FiberWriterSerializer());
+        kryo.addDefaultSerializer(CustomFiberWriter.class, new CustomFiberWriterSerializer());
+        kryo.register(Fiber.class);
+        kryo.register(ThreadLocal.class);
+        kryo.register(InheritableThreadLocal.class);
+        kryo.register(ThreadLocalSerializer.DEFAULT.class);
+        kryo.register(FiberWriter.class);
         return s;
     }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/io/serialization/Serialization.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/io/serialization/Serialization.java
@@ -37,17 +37,11 @@ public final class Serialization {
     private final IOStreamSerializer ioss;
 
     public static Serialization getInstance() {
-        if (instance != null)
-            return instance;
-        else
-            return tlInstance.get();
+        return (instance != null) ? instance : tlInstance.get();
     }
 
     public static Serialization newInstance() {
-        if (instance != null)
-            return instance;
-        else
-            return new Serialization(new KryoSerializer());
+        return (instance != null) ? instance : new Serialization(new KryoSerializer());
     }
 
     public static Kryo getKryo() {

--- a/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/KryoSerializer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/KryoSerializer.java
@@ -14,11 +14,13 @@ package co.paralleluniverse.io.serialization.kryo;
 
 import co.paralleluniverse.io.serialization.ByteArraySerializer;
 import co.paralleluniverse.io.serialization.IOStreamSerializer;
+import com.esotericsoftware.kryo.ClassResolver;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Registration;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.util.DefaultClassResolver;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -37,7 +39,11 @@ public class KryoSerializer implements ByteArraySerializer, IOStreamSerializer {
     private Output output;
 
     public KryoSerializer() {
-        this.kryo = KryoUtil.newKryo();
+        this(new DefaultClassResolver());
+    }
+
+    public KryoSerializer(ClassResolver classResolver) {
+        this.kryo = KryoUtil.newKryo(classResolver);
 
         KryoUtil.registerCommonClasses(kryo);
 

--- a/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/KryoUtil.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/KryoUtil.java
@@ -12,6 +12,7 @@
  */
 package co.paralleluniverse.io.serialization.kryo;
 
+import com.esotericsoftware.kryo.ClassResolver;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
@@ -25,13 +26,15 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import org.objenesis.strategy.SerializingInstantiatorStrategy;
 
+import static java.util.Collections.emptyMap;
+
 /**
  *
  * @author pron
  */
 public final class KryoUtil {
-    public static Kryo newKryo() {
-        Kryo kryo = new ReplaceableObjectKryo();
+    public static Kryo newKryo(ClassResolver classResolver) {
+        Kryo kryo = new ReplaceableObjectKryo(classResolver);
 
         kryo.setRegistrationRequired(false);
         kryo.setInstantiatorStrategy(new SerializingInstantiatorStrategy());
@@ -61,7 +64,7 @@ public final class KryoUtil {
         kryo.register(java.util.EnumSet.class);
 
         kryo.register(java.util.Arrays.asList("").getClass(), new ArraysAsListSerializer());
-        kryo.register(java.util.Collections.newSetFromMap(new java.util.HashMap()).getClass(), new CollectionsSetFromMapSerializer());
+        kryo.register(java.util.Collections.newSetFromMap(emptyMap()).getClass(), new CollectionsSetFromMapSerializer());
 //        kryo.register(java.util.Collections.EMPTY_LIST.getClass(), new CollectionsEmptyListSerializer());
 //        kryo.register(java.util.Collections.EMPTY_MAP.getClass(), new CollectionsEmptyMapSerializer());
 //        kryo.register(java.util.Collections.EMPTY_SET.getClass(), new CollectionsEmptySetSerializer());
@@ -72,7 +75,7 @@ public final class KryoUtil {
         kryo.register(java.lang.reflect.InvocationHandler.class, new JdkProxySerializer());
         UnmodifiableCollectionsSerializer.registerSerializers(kryo);
         SynchronizedCollectionsSerializer.registerSerializers(kryo);
-        kryo.addDefaultSerializer(Externalizable.class, new ExternalizableKryoSerializer());
+        kryo.addDefaultSerializer(Externalizable.class, new ExternalizableKryoSerializer<>());
         kryo.addDefaultSerializer(java.lang.ref.Reference.class, new ReferenceSerializer());
     }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/ReplaceableObjectKryo.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/ReplaceableObjectKryo.java
@@ -13,12 +13,14 @@
 package co.paralleluniverse.io.serialization.kryo;
 
 import co.paralleluniverse.common.reflection.GetAccessDeclaredMethod;
+import com.esotericsoftware.kryo.ClassResolver;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Registration;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
+import com.esotericsoftware.kryo.util.MapReferenceResolver;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -45,8 +47,9 @@ public class ReplaceableObjectKryo extends Kryo {
 
     @Override
     public void writeClassAndObject(Output output, Object object) {
-        if (output == null)
+        if (output == null) {
             throw new IllegalArgumentException("output cannot be null.");
+        }
         if (object == null) {
             super.writeClass(output, null);
             return;
@@ -60,21 +63,24 @@ public class ReplaceableObjectKryo extends Kryo {
 //        reset();
     }
 
-    public ReplaceableObjectKryo() {
+    public ReplaceableObjectKryo(ClassResolver classResolver) {
+        super(classResolver, new MapReferenceResolver());
     }
 
     @Override
     protected Serializer<?> newDefaultSerializer(Class type) {
         final Serializer<?> s = super.newDefaultSerializer(type);
-        if (s instanceof FieldSerializer)
+        if (s instanceof FieldSerializer) {
             ((FieldSerializer<?>) s).setIgnoreSyntheticFields(false);
+        }
         return s;
     }
 
     @Override
     public Registration writeClass(Output output, Class type) {
-        if (type == null || getMethods(type).writeReplace == null)
+        if (type == null || getMethods(type).writeReplace == null) {
             return super.writeClass(output, type);
+        }
         return super.getRegistration(type); // do nothing. write object will write the class too
     }
 
@@ -116,15 +122,15 @@ public class ReplaceableObjectKryo extends Kryo {
         return readReplace(super.readClassAndObject(input));
     }
 
+    @SuppressWarnings("unchecked")
     private <T> T readReplace(Object obj) {
-        if (obj == null)
-            return null;
-        return (T) getReplacement(getMethods(obj.getClass()).readResolve, obj);
+        return obj == null ? null : (T) getReplacement(getMethods(obj.getClass()).readResolve, obj);
     }
 
     private static Object getReplacement(Method m, Object object) {
-        if (m == null)
+        if (m == null) {
             return object;
+        }
         try {
             return m.invoke(object);
         } catch (IllegalAccessException e) {


### PR DESCRIPTION
Allow `Fiber.getFiberSerializer()` to specify the `ClassResolver` instance for Kryo to use. This means clients don't need to use Java reflection later to reset a `final` Kryo field.