### PR TITLE
NOTICK: Declare FiberWriter interfaces to be Serializable for lambdas.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/CustomFiberWriter.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/CustomFiberWriter.java
@@ -1,10 +1,13 @@
 package co.paralleluniverse.fibers;
 
+import java.io.Serializable;
+
 /**
  * A callback used by {@link Fiber#parkAndCustomSerialize(CustomFiberWriter)}.
  *
  * @author Christian Sailer (christian.sailer@r3.com)
  */
-public interface CustomFiberWriter {
+@FunctionalInterface
+public interface CustomFiberWriter extends Serializable {
     void write(Fiber fiber);
 }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/CustomFiberWriterSerializer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/CustomFiberWriterSerializer.java
@@ -9,6 +9,10 @@ import com.esotericsoftware.kryo.io.Output;
  * @author Christian Sailer (christian.sailer@r3.com)
  */
 public class CustomFiberWriterSerializer extends Serializer<CustomFiberWriter> {
+    public CustomFiberWriterSerializer() {
+        setImmutable(true);
+    }
+
     @Override
     public void write(Kryo kryo, Output output, CustomFiberWriter object) {
     }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberWriter.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberWriter.java
@@ -14,12 +14,14 @@
 package co.paralleluniverse.fibers;
 
 import co.paralleluniverse.io.serialization.ByteArraySerializer;
+import java.io.Serializable;
 
 /**
  * A callback used by {@link Fiber#parkAndSerialize(FiberWriter) Fiber.parkAndSerialize}..
  *
  * @author pron
  */
-public interface FiberWriter {
+@FunctionalInterface
+public interface FiberWriter extends Serializable {
     void write(Fiber fiber, ByteArraySerializer ser);
 }


### PR DESCRIPTION
Declare `FiberWriter` and `CustomFiberWriter` to extend `Serializable` so that they can both be implemented directly as lambdas.

Also declare `CustomFiberWriterSerializable` to be "immutable" like `FiberWriterSerializer` is.