### PR TITLE
CORE-12385: Ensure updates to ClassEntry objects are idempotent.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/ClassView.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/ClassView.java
@@ -1,0 +1,31 @@
+/*
+ * Quasar: lightweight threads and actors for the JVM.
+ * Copyright (c) 2013-2015, Parallel Universe Software Co. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 3.0
+ * as published by the Free Software Foundation.
+ */
+package co.paralleluniverse.fibers.instrument;
+
+/**
+ * A read-only view of {@link MethodDatabase.ClassEntry}.
+ */
+public interface ClassView {
+    String getSuperName();
+
+    String[] getInterfaces();
+
+    boolean isInterface();
+
+    String getSourceName();
+
+    String getSourceDebugInfo();
+
+    MethodDatabase.SuspendableType check(String name, String desc);
+}

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
@@ -256,15 +256,15 @@ public final class MethodDatabase {
         }
     }
 
-    Pair<MethodDatabase, ClassEntry> getOrLoadClassEntry(String className) {
+    Pair<MethodDatabase, ClassView> getOrLoadClassView(String className) {
         if (className.startsWith("[")) {
             // Don't try looking for an "array" class.
             return null;
         }
 
-        ClassEntry entry = getClassEntry(className);
-        if (entry != null) {
-            return new Pair<>(this, entry);
+        ClassView view = getClassEntry(className);
+        if (view != null) {
+            return new Pair<>(this, view);
         } else {
             final ClassLookup lookup = getLookupFor(className);
             if (lookup == null || lookup.getResource() == null) {
@@ -273,12 +273,12 @@ public final class MethodDatabase {
             } else {
                 final MethodDatabase ownerDB = lookup.toOwnerDB(this);
                 if (ownerDB != this) {
-                    entry = ownerDB.getClassEntry(className);
+                    view = ownerDB.getClassEntry(className);
                 }
-                if (entry == null) {
-                    entry = ownerDB.loadClassEntry(className, lookup.getResource());
+                if (view == null) {
+                    view = ownerDB.loadClassEntry(className, lookup.getResource());
                 }
-                return new Pair<>(ownerDB, entry);
+                return new Pair<>(ownerDB, view);
             }
         }
     }
@@ -292,17 +292,17 @@ public final class MethodDatabase {
             return SUSPENDABLE;
         }
 
-        final Pair<MethodDatabase, ClassEntry> dbEntry = getOrLoadClassEntry(className);
-        if (dbEntry == null) {
+        final Pair<MethodDatabase, ClassView> dbView = getOrLoadClassView(className);
+        if (dbView == null) {
             if (isJDK(className)) {
                 return JDK;
             }
             return UNKNOWN;
         }
 
-        final MethodDatabase ownerDB = dbEntry.getFirst();
-        final ClassEntry entry = dbEntry.getSecond();
-        final SuspendableType susp1 = entry.check(methodName, methodDesc);
+        final MethodDatabase ownerDB = dbView.getFirst();
+        final ClassView view = dbView.getSecond();
+        final SuspendableType susp1 = view.check(methodName, methodDesc);
 
         int suspendable = UNKNOWN;
         if (susp1 == SuspendableType.SUSPENDABLE) {
@@ -315,12 +315,12 @@ public final class MethodDatabase {
 
         if (suspendable == UNKNOWN) {
             if (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKESTATIC || opcode == Opcodes.INVOKESPECIAL) {
-                if (entry.getSuperName() != null) {
-                    suspendable = ownerDB.isMethodSuspendable0(entry.getSuperName(), methodName, methodDesc, opcode);
+                if (view.getSuperName() != null) {
+                    suspendable = ownerDB.isMethodSuspendable0(view.getSuperName(), methodName, methodDesc, opcode);
                 }
             }
             if (opcode == Opcodes.INVOKEINTERFACE || opcode == Opcodes.INVOKEVIRTUAL) { // can be INVOKEVIRTUAL on an abstract class implementing the interface
-                for (final String iface : entry.getInterfaces()) {
+                for (final String iface : view.getInterfaces()) {
                     int s = ownerDB.isMethodSuspendable0(iface, methodName, methodDesc, opcode);
                     if (s > suspendable) {
                         suspendable = s;
@@ -369,7 +369,7 @@ public final class MethodDatabase {
     void recordSuspendableMethods(String className, ClassEntry entry) {
         final ClassEntry oldEntry;
         synchronized(classes) {
-            oldEntry = classes.put(className, entry);
+            oldEntry = classes.putIfAbsent(className, entry);
         }
         if (oldEntry != null && oldEntry != entry) {
             if (!oldEntry.equals(entry)) {
@@ -620,7 +620,7 @@ public final class MethodDatabase {
         NON_SUSPENDABLE, SUSPENDABLE_SUPER, SUSPENDABLE
     }
 
-    public static final class ClassEntry {
+    public static final class ClassEntry implements ClassView {
         private final Map<String, SuspendableType> methods;
         private String sourceName;
         private String sourceDebugInfo;
@@ -640,6 +640,7 @@ public final class MethodDatabase {
             methods.put(nameAndDesc, suspendable);
         }
 
+        @Override
         public String getSourceName() {
             return sourceName;
         }
@@ -648,6 +649,7 @@ public final class MethodDatabase {
             this.sourceName = sourceName;
         }
 
+        @Override
         public String getSourceDebugInfo() {
             return sourceDebugInfo;
         }
@@ -656,6 +658,7 @@ public final class MethodDatabase {
             this.sourceDebugInfo = sourceDebugInfo;
         }
 
+        @Override
         public boolean isInterface() {
             return isInterface;
         }
@@ -664,6 +667,7 @@ public final class MethodDatabase {
             this.isInterface = isInterface;
         }
 
+        @Override
         public String getSuperName() {
             return superName;
         }
@@ -673,6 +677,7 @@ public final class MethodDatabase {
                 entry.setValue(suspendable);
         }
 
+        @Override
         public String[] getInterfaces() {
             return interfaces;
         }
@@ -681,6 +686,7 @@ public final class MethodDatabase {
             this.interfaces = interfaces;
         }
 
+        @Override
         public SuspendableType check(String name, String desc) {
             return methods.get(key(name, desc));
         }
@@ -716,6 +722,11 @@ public final class MethodDatabase {
             final ClassEntry other = (ClassEntry) obj;
             // CORDA-3756 names can be null.
             return Objects.equals(superName, other.superName) && methods.equals(other.methods);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("MethodDatabase$ClassEntry@%8x", System.identityHashCode(this));
         }
 
         private static String key(String methodName, String methodDesc) {

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SimpleSuspendableClassifier.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SimpleSuspendableClassifier.java
@@ -13,7 +13,6 @@
  */
 package co.paralleluniverse.fibers.instrument;
 
-import co.paralleluniverse.fibers.instrument.MethodDatabase.ClassEntry;
 import co.paralleluniverse.fibers.instrument.MethodDatabase.SuspendableType;
 import java.io.BufferedReader;
 import java.io.File;
@@ -154,11 +153,11 @@ final class SimpleSuspendableClassifier implements SuspendableClassifier {
             return SuspendableType.SUSPENDABLE_SUPER;
 
         if (superClassName != null) {
-            final Pair<MethodDatabase, ClassEntry> dbEntry = db.getOrLoadClassEntry(superClassName);
-            if (dbEntry != null) {
-                final MethodDatabase ownerDB = dbEntry.getFirst();
-                final ClassEntry ce = dbEntry.getSecond();
-                if (isSuspendable(ownerDB, sourceName, sourceDebugInfo, isInterface, superClassName, ce.getSuperName(), ce.getInterfaces(), methodName, methodDesc, methodSignature, methodExceptions) == SuspendableType.SUSPENDABLE) {
+            final Pair<MethodDatabase, ClassView> dbView = db.getOrLoadClassView(superClassName);
+            if (dbView != null) {
+                final MethodDatabase ownerDB = dbView.getFirst();
+                final ClassView cv = dbView.getSecond();
+                if (isSuspendable(ownerDB, sourceName, sourceDebugInfo, isInterface, superClassName, cv.getSuperName(), cv.getInterfaces(), methodName, methodDesc, methodSignature, methodExceptions) == SuspendableType.SUSPENDABLE) {
                     return SuspendableType.SUSPENDABLE;
                 }
             }
@@ -166,11 +165,11 @@ final class SimpleSuspendableClassifier implements SuspendableClassifier {
 
         if (interfaces != null) {
             for (final String iface : interfaces) {
-                final Pair<MethodDatabase, ClassEntry> dbEntry = db.getOrLoadClassEntry(iface);
-                if (dbEntry != null) {
-                    final MethodDatabase ownerDB = dbEntry.getFirst();
-                    final ClassEntry ce = dbEntry.getSecond();
-                    if (isSuspendable(ownerDB, ce.getSourceName(), ce.getSourceDebugInfo(), ce.isInterface(), iface, ce.getSuperName(), ce.getInterfaces(), methodName, methodDesc, methodSignature, methodExceptions) == SuspendableType.SUSPENDABLE) {
+                final Pair<MethodDatabase, ClassView> dbView = db.getOrLoadClassView(iface);
+                if (dbView != null) {
+                    final MethodDatabase ownerDB = dbView.getFirst();
+                    final ClassView cv = dbView.getSecond();
+                    if (isSuspendable(ownerDB, cv.getSourceName(), cv.getSourceDebugInfo(), cv.isInterface(), iface, cv.getSuperName(), cv.getInterfaces(), methodName, methodDesc, methodSignature, methodExceptions) == SuspendableType.SUSPENDABLE) {
                         return SuspendableType.SUSPENDABLE;
                     }
                 }
@@ -204,23 +203,23 @@ final class SimpleSuspendableClassifier implements SuspendableClassifier {
         if (className == null)
             return false;
 
-        final Pair<MethodDatabase, ClassEntry> dbEntry = db.getOrLoadClassEntry(className);
-        if (dbEntry != null) {
-            final MethodDatabase ownerDB = dbEntry.getFirst();
-            final ClassEntry ce = dbEntry.getSecond();
-            if (Objects.equals(superOrIface, ce.getSuperName())) {
+        final Pair<MethodDatabase, ClassView> dbView = db.getOrLoadClassView(className);
+        if (dbView != null) {
+            final MethodDatabase ownerDB = dbView.getFirst();
+            final ClassView cv = dbView.getSecond();
+            if (Objects.equals(superOrIface, cv.getSuperName())) {
                 return true;
             }
-            for (final String iface : ce.getInterfaces()) {
+            for (final String iface : cv.getInterfaces()) {
                 if (Objects.equals(superOrIface, iface)) {
                     return true;
                 }
             }
 
-            if (extendsOrImplements(superOrIface, ownerDB, ce.getSuperName())) {
+            if (extendsOrImplements(superOrIface, ownerDB, cv.getSuperName())) {
                 return true;
             }
-            for (final String iface : ce.getInterfaces()) {
+            for (final String iface : cv.getInterfaces()) {
                 if (extendsOrImplements(superOrIface, ownerDB, iface)) {
                     return true;
                 }


### PR DESCRIPTION
Do not allow `MethodDatabase.recordSuspendableMethods()` to replace a class's `ClassEntry` object, as this may prevent `QuasarWeavingHook` from finding the correct `ClassEntry.isInstrumented()` value when deciding whether or not to add extra `DynamicImport-Package` instructions.