### PR TITLE
CORE-12844 Wrong Kryo method used in CollectionSerializerAdapter 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-quasarVersion=0.9.1_r3-SNAPSHOT
+quasarVersion=0.9.0_r3-SNAPSHOT
 kotlinVersion=1.8.20
 taskTreeVersion=1.3.1
 shadowVersion=8.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-quasarVersion=0.9.0_r3-SNAPSHOT
+quasarVersion=0.9.1_r3-SNAPSHOT
 kotlinVersion=1.8.20
 taskTreeVersion=1.3.1
 shadowVersion=8.1.1

--- a/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/CollectionSerializableAdapter.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/io/serialization/kryo/CollectionSerializableAdapter.java
@@ -141,7 +141,7 @@ final class CollectionSerializerAdapter<T extends Collection<? super Object>> ex
     @Override
     public T read(Kryo kryo, Input input, Class<? extends T> type) {
         try {
-            int length = input.readVarIntFlag(true);
+            int length = input.readVarInt(true);
             if (length == 0) {
                 return null;
             }


### PR DESCRIPTION
Fixed usage of wrong Kryo method in CollectionSerializerAdapter (using `readVarInt` instead of `readVarIntFlag`)