### PR TITLE
CORE-12882: Upgrade to ASM 9.5.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ testJavaVersion=17
 
 kotlin.stdlib.default.dependency=false
 
-asmVersion=9.4
+asmVersion=9.5
 
 felixVersion=7.0.5
 felixConfigAdminVersion=1.9.26


### PR DESCRIPTION
Upgrade to ASM 9.5 to fix broken handling of `LineNumberTable`.