### PR TITLE
CORE-12882: Upgrade to ASM 9.5. (#150)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ modulepluginVersion=1.8.12
 
 kotlin.stdlib.default.dependency=false
 
-asmVersion=9.4
+asmVersion=9.5
 
 felixVersion=7.0.5
 felixConfigAdminVersion=1.9.26


### PR DESCRIPTION
Upgrade to ASM 9.5 to fix broken handling of `LineNumberTable`.
