### PR TITLE
CORE-13260: Upgrade to Gradle 8.1.1 and Kotlin 1.8.21.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,7 @@ subprojects {
 
         // Quasar needs reflective access to these packages.
         jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+                '--add-opens', 'java.base/java.time=ALL-UNNAMED',
                 '--add-opens', 'java.base/java.util=ALL-UNNAMED'
                 '--illegal-access=warn'
     }
@@ -247,7 +248,7 @@ subprojects {
         project.task(name, type: JavaExec, dependsOn:[testClasses]) {
             classpath = sourceSets.main.runtimeClasspath
             if(project.hasProperty('mainClass')){
-                main = project.mainClass
+                mainClass = project.mainClass
             }
             if(project.hasProperty('args')){
                 args project.args.split('\\s+')
@@ -989,6 +990,6 @@ artifactory {
 }
 
 wrapper {
-    gradleVersion = '8.1'
+    gradleVersion = '8.1.1'
     distributionType = Wrapper.DistributionType.BIN
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 quasarVersion=0.9.0_r3-SNAPSHOT
-kotlinVersion=1.8.20
+kotlinVersion=1.8.21
 taskTreeVersion=1.3.1
 shadowVersion=8.1.1
-artifactoryVersion=4.21.0
+artifactoryVersion=4.31.9
 assertjVersion=3.22.0
 bndVersion=6.4.0
 modulepluginVersion=1.8.12

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/quasar-core/src/main/java/co/paralleluniverse/common/resource/ClassLoaderUtil.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/resource/ClassLoaderUtil.java
@@ -238,7 +238,7 @@ public final class ClassLoaderUtil {
      * Worker class for {@link #getBestClassLoader(ClassLoader, String, URL)}.
      * We need to search from the bootstrap classloader upwards in order to
      * mirror how {@link ClassLoader#getResource(String)} works.
-     *
+     * <p>
      * We are expected already to be running with the correct security context.
      */
     private static final class BestLookup {

--- a/quasar-core/src/test/java/co/paralleluniverse/io/serialization/kryo/JavaTimeTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/io/serialization/kryo/JavaTimeTest.java
@@ -1,0 +1,70 @@
+package co.paralleluniverse.io.serialization.kryo;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.util.DefaultClassResolver;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+/**
+ * Check that we can serialize and deserialize these {@link java.time} classes,
+ * which implement {@code writeReplace} and {@code readResolve}.
+ */
+public class JavaTimeTest {
+    private static final int BUFFER_SIZE = 8192;
+
+    private final Kryo kryo = KryoUtil.newKryo(new DefaultClassResolver());
+
+    @Test
+    public void testInstant() {
+        final Instant source = Instant.now();
+        final Instant result = serializeAndDeserialize(source);
+
+        assertEquals(source.getClass(), result.getClass());
+        assertNotSame(source, result);
+        assertEquals(source, result);
+    }
+
+    @Test
+    public void testDuration() {
+        final Duration source = Duration.of(100, ChronoUnit.HOURS);
+        final Duration result = serializeAndDeserialize(source);
+
+        assertEquals(source.getClass(), result.getClass());
+        assertNotSame(source, result);
+        assertEquals(source, result);
+    }
+
+    @Test
+    public void testPeriod() {
+        final Period source = Period.of(100, 2, 20);
+        final Period result = serializeAndDeserialize(source);
+
+        assertEquals(source.getClass(), result.getClass());
+        assertNotSame(source, result);
+        assertEquals(source, result);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Serializable> T serializeAndDeserialize(T source) {
+        final byte[] buffer;
+
+        try (Output output = new Output(BUFFER_SIZE)) {
+            kryo.writeClassAndObject(output, source);
+            buffer = output.getBuffer();
+        }
+
+        try (Input input = new Input(buffer)) {
+            return (T) kryo.readClassAndObject(input);
+        }
+    }
+}


### PR DESCRIPTION
Perform the following upgrades:
- Gradle 8.1 -> 8.1.1
- Kotlin 1.8.20 -> 1.8.21
- Artifactory plugin 4.21.0 -> 4.31.9

Also provide unit test for serializing / deserializing `java.time.*` classes, which implement `writeReplace` and `readResolve`.