### PR TITLE
NOTICK: Match Gradle's own version of Ant.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ subprojects {
             }
         }
 
-        provided "org.apache.ant:ant:1.10.5"
+        provided "org.apache.ant:ant:$antVersion"
         timewarp 'co.paralleluniverse:timewarp:0.2.0-SNAPSHOT'
         testImplementation 'junit:junit:4.13.2'
         testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,9 @@ assertjVersion=3.22.0
 bndVersion=6.4.0
 modulepluginVersion=1.8.12
 
+# Actually provided by Gradle.
+antVersion=1.10.11
+
 targetJavaVersion=11
 testJavaVersion=17
 


### PR DESCRIPTION
Gradle 8.1.1 is actually using Ant 1.10.11