### PR TITLE
CORE-14244: Allow file cache to work without POSIX file attributes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -513,6 +513,9 @@ project (':quasar-core') {
         frameworkExtensionImplementation files(sourceSets.main.output) {
             builtBy tasks.named('compileJava', JavaCompile)
         }
+
+        testImplementation "com.google.jimfs:jimfs:$jimfsVersion"
+        testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
     }
 
     tasks.named('compileFrameworkExtensionJava', JavaCompile) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,7 @@ felixSecurityVersion=2.8.4
 byteBuddyVersion=1.14.2
 dropWizardVersion=4.1.0
 guavaVersion=30.1.1-jre
+jimfsVersion=1.2
 junitJupiterVersion=5.9.2
 junitPlatformVersion=1.9.2
 kryoVersion=5.5.0

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/ByteCodeFileCache.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/ByteCodeFileCache.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
@@ -43,7 +44,7 @@ final class ByteCodeFileCache implements ByteCodeCache {
     }
 
     private boolean exists(Path file) {
-        return doPrivileged((PrivilegedAction<Boolean>)() -> Files.exists(file));
+        return doPrivileged((PrivilegedAction<Boolean>)() -> Files.isRegularFile(file));
     }
 
     private Path createCacheFile(CacheKey key) {
@@ -59,16 +60,23 @@ final class ByteCodeFileCache implements ByteCodeCache {
             .resolve(builder.toString());
     }
 
+    private static FileAttribute<?>[] posixOptional(Path path, FileAttribute<?> attr) {
+        return Files.getFileAttributeView(path, PosixFileAttributeView.class) != null
+            ? new FileAttribute<?>[] { attr } : new FileAttribute<?>[0];
+    }
+
     private Path writeToCache(Path cacheFile, byte[] byteCode) throws IOException {
         final Path tempFile = Files.createTempFile(
-            Files.createDirectories(cacheFile.getParent(), RWX_RX_RX_ATTR),
+            Files.createDirectories(cacheFile.getParent(), posixOptional(cacheFile, RWX_RX_RX_ATTR)),
             ".quasar",
             ".class",
-            RW_ATTR
+            posixOptional(cacheFile, RW_ATTR)
         );
         try {
-            Files.write(tempFile, byteCode);
-            Files.setPosixFilePermissions(tempFile, READ_ONLY);
+            final PosixFileAttributeView posix = Files.getFileAttributeView(Files.write(tempFile, byteCode), PosixFileAttributeView.class);
+            if (posix != null) {
+                posix.setPermissions(READ_ONLY);
+            }
             return Files.move(tempFile, cacheFile, ATOMIC_MOVE);
         } catch(IOException e) {
             Files.delete(tempFile);

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/ByteCodeFileCacheUnixTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/ByteCodeFileCacheUnixTest.java
@@ -1,0 +1,132 @@
+package co.paralleluniverse.fibers.instrument;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_READ;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_READ;
+import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
+import static java.util.stream.Collectors.toUnmodifiableList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class ByteCodeFileCacheUnixTest {
+    private static final Log LOG = new TestLogger(LoggerFactory.getLogger(ByteCodeFileCacheUnixTest.class));
+    private static final FileAttribute<?> OWNER_ONLY = asFileAttribute(Set.of(OWNER_EXECUTE, OWNER_READ, OWNER_WRITE));
+    private static final String TEST_CLASS_NAME = "org.testing.UnixExample";
+    private static final String ALGORITHM_NAME = "SHA-256";
+    private static final Random RANDOM = new Random();
+    private static final String CACHE_ROOT = "cache";
+    private static final int ARRAY_SIZE = 1024;
+
+    private FileSystem fileSystem;
+    private ByteCodeCache cache;
+    private Path cacheDirectory;
+
+    private static byte[] createRandomBytes() {
+        final byte[] bytes = new byte[ARRAY_SIZE];
+        RANDOM.nextBytes(bytes);
+        return bytes;
+    }
+
+    private static byte[] hashOf(byte[] bytes) throws NoSuchAlgorithmException {
+        return MessageDigest.getInstance(ALGORITHM_NAME).digest(bytes);
+    }
+
+    static String toHex(byte b) {
+        return String.format("%02x", Byte.toUnsignedInt(b));
+    }
+
+    static String toHex(byte[] bytes) {
+        StringBuilder builder = new StringBuilder();
+        for (byte b : bytes) {
+            builder.append(toHex(b));
+        }
+        return builder.toString();
+    }
+
+    static List<Path> getAllFiles(Path root) throws IOException {
+        try (Stream<Path> walk = Files.walk(root)) {
+            return walk.filter(Files::isRegularFile).collect(toUnmodifiableList());
+        }
+    }
+
+    private static String absoluteUnixPathOf(byte[] source) throws NoSuchAlgorithmException {
+        assertThat(source).hasSizeGreaterThanOrEqualTo(2);
+        final byte[] bytes = hashOf(source);
+        return CACHE_ROOT + '/'
+            + toHex(bytes[0]) + '/'
+            + toHex(bytes[1]) + '/'
+            + toHex(Arrays.copyOfRange(bytes, 2, bytes.length))
+            + '.' + Integer.toHexString(source.length);
+    }
+
+    @Before
+    public void setup() throws IOException, NoSuchAlgorithmException {
+        Configuration posix = Configuration.unix().toBuilder()
+            .setAttributeViews("basic", "posix")
+            .build();
+        fileSystem = Jimfs.newFileSystem("posix", posix);
+
+        cacheDirectory = Files.createDirectory(fileSystem.getPath(CACHE_ROOT), OWNER_ONLY);
+        cache = new ByteCodeFileCache(ByteCodeCache.createKeyFactory(ALGORITHM_NAME), cacheDirectory, LOG);
+    }
+
+    @After
+    public void done() throws IOException {
+        fileSystem.close();
+    }
+
+    @Test
+    public void testNewFileIsCached() throws Exception {
+        final byte[] source = createRandomBytes();
+        final byte[] target = new byte[ARRAY_SIZE];
+        Arrays.fill(target, (byte) 0x7b);
+        final byte[] result = cache.computeIfAbsent(TEST_CLASS_NAME, source, () -> target);
+        assertArrayEquals(target, result);
+
+        // One file has been created in the cache.
+        final List<Path> classes = getAllFiles(cacheDirectory);
+        assertThat(classes).hasSize(1);
+
+        // This file has the correct contents and properties.
+        final Path cacheFile = classes.get(0);
+        assertArrayEquals(target, Files.readAllBytes(cacheFile));
+        assertThat(Files.getPosixFilePermissions(cacheFile)).containsExactlyInAnyOrder(OWNER_READ);
+        assertEquals(absoluteUnixPathOf(source), cacheFile.toString());
+
+        // And its parent directories have the correct permissions.
+        assertThat(Files.getPosixFilePermissions(cacheFile.getParent()))
+            .containsExactlyInAnyOrder(OWNER_READ, OWNER_EXECUTE, OWNER_WRITE, GROUP_READ, GROUP_EXECUTE, OTHERS_EXECUTE, OTHERS_READ);
+        assertThat(Files.getPosixFilePermissions(cacheFile.getParent().getParent()))
+            .containsExactlyInAnyOrder(OWNER_READ, OWNER_EXECUTE, OWNER_WRITE, GROUP_READ, GROUP_EXECUTE, OTHERS_EXECUTE, OTHERS_READ);
+
+        // And we can retrieve this entry from the cache.
+        final byte[] cachedResult = cache.computeIfAbsent(TEST_CLASS_NAME, source, () -> fail("Not allowed."));
+        assertArrayEquals(target, cachedResult);
+    }
+}

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/ByteCodeFileCacheWindowsTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/ByteCodeFileCacheWindowsTest.java
@@ -1,0 +1,94 @@
+package co.paralleluniverse.fibers.instrument;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static co.paralleluniverse.fibers.instrument.ByteCodeFileCacheUnixTest.getAllFiles;
+import static co.paralleluniverse.fibers.instrument.ByteCodeFileCacheUnixTest.toHex;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class ByteCodeFileCacheWindowsTest {
+    private static final Log LOG = new TestLogger(LoggerFactory.getLogger(ByteCodeFileCacheUnixTest.class));
+    private static final String TEST_CLASS_NAME = "org.testing.WindowsExample";
+    private static final String ALGORITHM_NAME = "SHA-256";
+    private static final Random RANDOM = new Random();
+    private static final String CACHE_ROOT = "C:\\cache";
+    private static final int ARRAY_SIZE = 1024;
+
+    private FileSystem fileSystem;
+    private ByteCodeCache cache;
+    private Path cacheDirectory;
+
+    private static byte[] createRandomBytes() {
+        final byte[] bytes = new byte[ARRAY_SIZE];
+        RANDOM.nextBytes(bytes);
+        return bytes;
+    }
+
+    private static byte[] hashOf(byte[] bytes) throws NoSuchAlgorithmException {
+        return MessageDigest.getInstance(ALGORITHM_NAME).digest(bytes);
+    }
+
+    private static String absoluteWindowsPathOf(byte[] source) throws NoSuchAlgorithmException {
+        assertThat(source).hasSizeGreaterThanOrEqualTo(2);
+        final byte[] bytes = hashOf(source);
+        return CACHE_ROOT + '\\'
+            + toHex(bytes[0]) + '\\'
+            + toHex(bytes[1]) + '\\'
+            + toHex(Arrays.copyOfRange(bytes, 2, bytes.length))
+            + '.' + Integer.toHexString(source.length);
+    }
+
+    @Before
+    public void setup() throws NoSuchAlgorithmException, IOException {
+        fileSystem = Jimfs.newFileSystem(Configuration.windows());
+
+        cacheDirectory = Files.createDirectory(fileSystem.getPath(CACHE_ROOT));
+        cache = new ByteCodeFileCache(ByteCodeCache.createKeyFactory(ALGORITHM_NAME), cacheDirectory, LOG);
+    }
+
+    @After
+    public void done() throws IOException {
+        fileSystem.close();
+    }
+
+    @Test
+    public void testNewFileIsCached() throws Exception {
+        final byte[] source = createRandomBytes();
+        final byte[] target = new byte[ARRAY_SIZE];
+        Arrays.fill(target, (byte) 0x7b);
+        final byte[] result = cache.computeIfAbsent(TEST_CLASS_NAME, source, () -> target);
+        assertArrayEquals(target, result);
+
+        // One file has been created in the cache.
+        final List<Path> classes = getAllFiles(cacheDirectory);
+        assertThat(classes).hasSize(1);
+
+        // This file has the correct contents and properties.
+        final Path cacheFile = classes.get(0);
+        assertArrayEquals(target, Files.readAllBytes(cacheFile));
+        assertEquals(absoluteWindowsPathOf(source), cacheFile.toString());
+
+        // And we can retrieve this entry from the cache.
+        final byte[] cachedResult = cache.computeIfAbsent(TEST_CLASS_NAME, source, () -> fail("Not allowed"));
+        assertArrayEquals(target, cachedResult);
+    }
+}

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/CatchTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/CatchTest.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.*;
  * @author Matthias Mann
  */
 public class CatchTest {
-    private final ArrayList<String> results = new ArrayList<String>();
+    private final ArrayList<String> results = new ArrayList<>();
 
     class Runnable1 implements SuspendableRunnable {
         int cnt = 0;

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/TestLogger.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/TestLogger.java
@@ -1,0 +1,39 @@
+package co.paralleluniverse.fibers.instrument;
+
+import org.slf4j.Logger;
+
+public final class TestLogger implements Log {
+    private final Logger logger;
+
+    public TestLogger(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void log(LogLevel level, String msg, Object... args) {
+        switch (level) {
+            case DEBUG:
+                if (logger.isDebugEnabled()) {
+                    logger.debug(String.format(msg, args));
+                }
+                break;
+
+            case INFO:
+                if (logger.isInfoEnabled()) {
+                    logger.info(String.format(msg, args));
+                }
+                break;
+
+            case WARNING:
+                if (logger.isWarnEnabled()) {
+                    logger.warn(String.format(msg, args));
+                }
+                break;
+        }
+    }
+
+    @Override
+    public void error(String msg, Throwable ex) {
+        logger.error(msg, ex);
+    }
+}


### PR DESCRIPTION
Only use POSIX file attributes if the file system supports them.