### PR TITLE
CORE-14504: Upgrade to Bndlib 6.4.1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,28 @@ plugins {
 }
 
 subprojects {
+    buildscript {
+        dependencies {
+            constraints {
+                classpath('biz.aQute.bnd:biz.aQute.bndlib') {
+                    version {
+                        require bndlibVersion
+                    }
+                }
+                classpath('biz.aQute.bnd:biz.aQute.bnd.embedded-repo') {
+                    version {
+                        require bndlibVersion
+                    }
+                }
+                classpath('biz.aQute.bnd:biz.aQute.resolve') {
+                    version {
+                        require bndlibVersion
+                    }
+                }
+            }
+        }
+    }
+
     apply plugin: 'java-library'
     apply plugin: 'org.javamodularity.moduleplugin'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ shadowVersion=8.1.1
 artifactoryVersion=4.31.9
 assertjVersion=3.22.0
 bndVersion=6.4.0
+bndlibVersion=6.4.1
 modulepluginVersion=1.8.12
 
 # Actually provided by Gradle.


### PR DESCRIPTION
Upgrade to Bndlib 6.4.1, although the latest Bnd Gradle plugin is still 6.4.0.