### PR TITLE
CORE-13560: Replace FieldSerializer cache using SerializerFactory.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
@@ -42,6 +42,7 @@ import com.esotericsoftware.kryo.ClassResolver;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Registration;
 import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.SerializerFactory.BaseSerializerFactory;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
@@ -2168,11 +2169,10 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
     public static ByteArraySerializer getFiberSerializer(ClassResolver classResolver, boolean includeThreadLocals) {
         final KryoSerializer s = new KryoSerializer(classResolver);
         final Kryo kryo = s.getKryo();
-        kryo.addDefaultSerializer(Fiber.class, new FiberSerializer(includeThreadLocals));
+        kryo.addDefaultSerializer(Fiber.class, new FiberSerializerFactory(includeThreadLocals));
         kryo.addDefaultSerializer(ThreadLocal.class, new ThreadLocalSerializer());
         kryo.addDefaultSerializer(FiberWriter.class, new FiberWriterSerializer());
         kryo.addDefaultSerializer(CustomFiberWriter.class, new CustomFiberWriterSerializer());
-        kryo.register(Fiber.class);
         kryo.register(ThreadLocal.class);
         kryo.register(InheritableThreadLocal.class);
         kryo.register(ThreadLocalSerializer.DEFAULT.class);
@@ -2180,10 +2180,25 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
         return s;
     }
 
-    private static final class FiberSerializer extends Serializer<Fiber<?>> {
+    private static final class FiberSerializerFactory extends BaseSerializerFactory<FiberSerializer> {
         private final boolean includeThreadLocals;
 
-        public FiberSerializer(boolean includeThreadLocals) {
+        FiberSerializerFactory(boolean includeThreadLocals) {
+            this.includeThreadLocals = includeThreadLocals;
+        }
+
+        @Override
+        public FiberSerializer newSerializer(Kryo kryo, Class type) {
+            return new FiberSerializer(new FieldSerializer<>(kryo, type), includeThreadLocals);
+        }
+    }
+
+    private static final class FiberSerializer extends Serializer<Fiber<?>> {
+        private final FieldSerializer<Fiber<?>> fieldSerializer;
+        private final boolean includeThreadLocals;
+
+        FiberSerializer(FieldSerializer<Fiber<?>> fieldSerializer, boolean includeThreadLocals) {
+            this.fieldSerializer = fieldSerializer;
             this.includeThreadLocals = includeThreadLocals;
             setImmutable(true);
         }
@@ -2203,7 +2218,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
                 try {
                     f.stack.resumeStack();
                     kryo.writeClass(output, f.getClass());
-                    new FieldSerializer<>(kryo, f.getClass()).write(kryo, output, f);
+                    fieldSerializer.write(kryo, output, f);
                 } finally {
                     f.fiberLocals = tmpFiberLocals;
                     f.inheritableFiberLocals = tmpInheritableFiberLocals;
@@ -2224,7 +2239,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
                     f.stack.resumeStack();
 
                     kryo.writeClass(output, f.getClass());
-                    new FieldSerializer<>(kryo, f.getClass()).write(kryo, output, f);
+                    fieldSerializer.write(kryo, output, f);
                 } catch (Throwable t) {
                     t.printStackTrace();
                     throw t;
@@ -2238,7 +2253,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
         }
 
         @Override
-        @SuppressWarnings("CallToPrintStackTrace")
+        @SuppressWarnings({ "CallToPrintStackTrace", "unchecked" })
         public Fiber<?> read(Kryo kryo, Input input, Class<? extends Fiber<?>> type) {
             final Fiber<?> f;
             final Thread currentThread = Thread.currentThread();
@@ -2251,7 +2266,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
                 if (reg == null) {
                     return null;
                 }
-                f = (Fiber<?>) new FieldSerializer<>(kryo, reg.getType()).read(kryo, input, reg.getType());
+                f = fieldSerializer.read(kryo, input, (Class<? extends Fiber<?>>) reg.getType());
 
                 if (!f.noLocals) {
                     f.fiberLocals = ThreadAccess.getThreadLocals(currentThread);

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
@@ -62,8 +62,6 @@ import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -92,6 +90,7 @@ import static java.security.AccessController.doPrivileged;
  *
  * @author pron
  */
+@SuppressWarnings("removal")
 public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Future<V> {
     static final boolean USE_VAL_FOR_RESULT = true;
     private static final Object RESET = new Object();
@@ -2183,11 +2182,6 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
 
     private static final class FiberSerializer extends Serializer<Fiber<?>> {
         private final boolean includeThreadLocals;
-        private final Map<Class<? extends Fiber<?>>, FieldSerializer<Fiber<?>>> fieldSerializers = new HashMap<>();
-
-        private FieldSerializer<Fiber<?>> getFieldSerializer(Kryo kryo, Class<? extends Fiber<?>> fiberClass) {
-            return fieldSerializers.computeIfAbsent(fiberClass, fc -> new FieldSerializer<>(kryo, fc));
-        }
 
         public FiberSerializer(boolean includeThreadLocals) {
             this.includeThreadLocals = includeThreadLocals;
@@ -2195,7 +2189,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
         }
 
         @Override
-        @SuppressWarnings({"CallToPrintStackTrace", "unchecked"})
+        @SuppressWarnings("CallToPrintStackTrace")
         public void write(Kryo kryo, Output output, Fiber<?> f) {
             final Thread currentThread = Thread.currentThread();
 
@@ -2209,7 +2203,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
                 try {
                     f.stack.resumeStack();
                     kryo.writeClass(output, f.getClass());
-                    getFieldSerializer(kryo, (Class<? extends Fiber<?>>) f.getClass()).write(kryo, output, f);
+                    new FieldSerializer<>(kryo, f.getClass()).write(kryo, output, f);
                 } finally {
                     f.fiberLocals = tmpFiberLocals;
                     f.inheritableFiberLocals = tmpInheritableFiberLocals;
@@ -2230,7 +2224,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
                     f.stack.resumeStack();
 
                     kryo.writeClass(output, f.getClass());
-                    getFieldSerializer(kryo, (Class<? extends Fiber<?>>) f.getClass()).write(kryo, output, f);
+                    new FieldSerializer<>(kryo, f.getClass()).write(kryo, output, f);
                 } catch (Throwable t) {
                     t.printStackTrace();
                     throw t;
@@ -2244,7 +2238,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
         }
 
         @Override
-        @SuppressWarnings({"CallToPrintStackTrace", "unchecked"})
+        @SuppressWarnings("CallToPrintStackTrace")
         public Fiber<?> read(Kryo kryo, Input input, Class<? extends Fiber<?>> type) {
             final Fiber<?> f;
             final Thread currentThread = Thread.currentThread();
@@ -2254,9 +2248,10 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
             ThreadAccess.setInheritableThreadLocals(currentThread, null);
             try {
                 final Registration reg = kryo.readClass(input);
-                if (reg == null)
+                if (reg == null) {
                     return null;
-                f = (Fiber<?>) getFieldSerializer(kryo, reg.getType()).read(kryo, input, reg.getType());
+                }
+                f = (Fiber<?>) new FieldSerializer<>(kryo, reg.getType()).read(kryo, input, reg.getType());
 
                 if (!f.noLocals) {
                     f.fiberLocals = ThreadAccess.getThreadLocals(currentThread);


### PR DESCRIPTION
~The `FieldSerializer` retrieved from the cache is bound to its own instance of Kryo, which may not be the same instance that the thread wants to use.~

This cache is better implemented using a Kryo `SerializerFactory` rather than a home-grown approach. The `HashMap` approach has shown to be susceptible to `ConcurrentModificationException` problems.

Reverting this obviously reintroduces the original performance issue that creating a new `FieldSerializer` instance every time can be _S-L-O-W_, and so we need an alternative solution for that.

Register a `FiberSerializerFactory` with Kryo instead of `FiberSerializer`. This allows us to defer creating the `FieldSerializer` until we know what the _exact_ type of the `Fiber` object is, at which point we can create both the `FiberSerializer` and its `FieldSerializer` together. In theory, this means we will only create that particular `Fiber` sub-class's `FieldSerializer` _once_.

---
Do not register a Kryo serializer for the `Fiber` class because our fibers are actually instances of `FlowFiberImpl`. Consequently, creating a `FieldSerializer` for `Fiber` whenever we create a new `Kryo` instance is an expensive waste of time.