### PR TITLE
ES-1030: Add S3 artifact publishing 

### DIFF
--- a/.ci/dev/Jenkinsfile
+++ b/.ci/dev/Jenkinsfile
@@ -63,12 +63,12 @@ pipeline {
         AWS_CREDENTIALS=credentials("s3-prod-uploader")
       }
       steps {
-        sh './gradlew publish artifactoryPublish \
+        sh '''./gradlew publish artifactoryPublish \
           --no-daemon \
           -Pcompilation.allWarningsAsErrors=true \
           -Ptests.failFast=false \
           -Ptests.ignoreFailures=true \
-          -Pmaven.repo.s3="${S3_PATH}"'
+          -Pmaven.repo.s3="${S3_PATH}"'''
       }
     }
   }

--- a/.ci/dev/Jenkinsfile
+++ b/.ci/dev/Jenkinsfile
@@ -58,7 +58,6 @@ pipeline {
       }
       environment {
         S3_BUCKET=credentials("maven-s3-prod-bucket")
-        PUBLIC_URL=credentials('maven-s3-bucket-https-path')
         S3_PATH="s3://${env.S3_BUCKET}/maven/${env.CORDA_ARTIFACTORY_REPOKEY}"
         AWS_CREDENTIALS=credentials("s3-prod-uploader")
       }

--- a/.ci/dev/Jenkinsfile
+++ b/.ci/dev/Jenkinsfile
@@ -34,7 +34,8 @@ pipeline {
   stages {
     stage('Compile') {
       steps {
-        sh '''./gradlew clean assemble --no-daemon \
+        sh '''./gradlew clean assemble \
+          --no-daemon \
           -Pcompilation.allWarningsAsErrors=true \
           -Ptests.failFast=false \
           -Ptests.ignoreFailures=true'''

--- a/.ci/dev/Jenkinsfile
+++ b/.ci/dev/Jenkinsfile
@@ -34,13 +34,20 @@ pipeline {
   stages {
     stage('Compile') {
       steps {
-        sh "./gradlew --no-daemon -Pcompilation.allWarningsAsErrors=true -Ptests.failFast=false -Ptests.ignoreFailures=true clean assemble"
+        sh '''./gradlew clean assemble --no-daemon \
+          -Pcompilation.allWarningsAsErrors=true \
+          -Ptests.failFast=false \
+          -Ptests.ignoreFailures=true'''
       }
     }
 
     stage('Test') {
       steps {
-        sh "./gradlew --no-daemon -Pcompilation.allWarningsAsErrors=true -Ptests.failFast=false -Ptests.ignoreFailures=true testClasses test"
+        sh '''./gradlew testClasses test \
+          --no-daemon \
+          -Pcompilation.allWarningsAsErrors=true \
+          -Ptests.failFast=false \
+          -Ptests.ignoreFailures=true'''
       }
     }
 
@@ -49,8 +56,19 @@ pipeline {
         expression { params.DO_PUBLISH }
         beforeAgent true
       }
+      environment {
+        S3_BUCKET=credentials("maven-s3-prod-bucket")
+        PUBLIC_URL=credentials('maven-s3-bucket-https-path')
+        S3_PATH="s3://${env.S3_BUCKET}/maven/${env.CORDA_ARTIFACTORY_REPOKEY}"
+        AWS_CREDENTIALS=credentials("s3-prod-uploader")
+      }
       steps {
-        sh "./gradlew --no-daemon -Pcompilation.allWarningsAsErrors=true -Ptests.failFast=false -Ptests.ignoreFailures=true artifactoryPublish"
+        sh './gradlew publish artifactoryPublish \
+          --no-daemon \
+          -Pcompilation.allWarningsAsErrors=true \
+          -Ptests.failFast=false \
+          -Ptests.ignoreFailures=true \
+          -Pmaven.repo.s3="${S3_PATH}"'
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -803,6 +803,19 @@ configure(publishedProjects) { subproject ->
                 }
             }
         }
+        if (subproject.hasProperty('maven.repo.s3')) {
+            repositories {
+                maven {
+                    name = 'AWS'
+                    url = subproject.findProperty('maven.repo.s3')
+                    credentials(AwsCredentials) {
+                        accessKey "${System.getenv('AWS_ACCESS_KEY_ID')}"
+                        secretKey "${System.getenv('AWS_SECRET_ACCESS_KEY')}"
+                        sessionToken "${System.getenv('AWS_SESSION_TOKEN')}"
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
- Add `S3` publishing to the Quasar project, Due to a change in the way we use Artifactory, we will also now publish any libraries which the OS community may need to a location in S3, which also acts as a Maven Repository. `corda-dependencies`  and `corda-dependencies-dev` will be coming private in the near future so external open source consumers will need to resolve dependencies from this new S3 maven repo, Work has already been done to update various Corda projects to consume from here. 

Also, a nightly sync job copies from the Artifactory location to S3, however, for key projects such as this, we should push directly to the S3 location so new versions are available immediately to the OS builds.

Changes include:
- Add needed logic to the `publishing` block in `build.gradle` file.
- Add `publish` task to `Jenkinsfie` (which it's not on the task dependency graph for `artifactoryPublish` task so needs to be explicitly called)
- Pass the needed `-Pmaven.repo.s3` to the publishing stage, which will trigger the new logic in build.gradle
- Formatting to Jenkins file for easier readability, move tasks before properties and spit into a multiline call

There is no functional change to the behavior of this project apart from the addition of S3 publishing introduced by this PR 

**Note: further PR's yet to be raised will handle other release branches** 
