### PR TITLE
CORE-16998: Fix Quasar to support all felix.bootdelegation.implicit options.

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/common/resource/ClassLoaderUtil.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/resource/ClassLoaderUtil.java
@@ -264,7 +264,7 @@ public final class ClassLoaderUtil {
                 // Support jars added via -Xbootclasspath/a:<jar>. This probably
                 // KILLS performance, but I cannot find any other way to search
                 // the JVM's entire boot classpath.
-                if (target.equals(platformClassLoader.getResource(resourceName))) {
+                if (isEqual(target, platformClassLoader.getResource(resourceName))) {
                     return platformClassLoader;
                 }
             } else {
@@ -278,11 +278,18 @@ public final class ClassLoaderUtil {
                     if (isTargetFrom(((URLClassLoader) current).getURLs())) {
                         return current;
                     }
-                } else if (target.equals(current.getResource(resourceName))) {
+                } else if (isEqual(target, current.getResource(resourceName))) {
                     return current;
                 }
             }
             return null;
+        }
+
+        // This is safer than URL.equals(Object) for file, jar and bundle URLs.
+        private static boolean isEqual(URL a, URL b) {
+            return (a == b) || (
+                (a != null) && (b != null) && a.getProtocol().equals(b.getProtocol()) && a.getPath().equals(b.getPath())
+            );
         }
 
         private boolean isTargetFrom(URL[] urls) {
@@ -309,7 +316,7 @@ public final class ClassLoaderUtil {
         String classpathAttribute = manifest.getMainAttributes().getValue(Attributes.Name.CLASS_PATH.toString());
         if (classpathAttribute != null) {
             for (String path : classpathAttribute.split("\\s")) {
-                if (path != null && path.trim().length() > 0) {
+                if (path != null && !path.trim().isEmpty()) {
                     URI uri;
                     try {
                         uri = getClassPathEntry(jarFile, path.trim());

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
@@ -500,7 +500,20 @@ public final class MethodDatabase {
 
     private ClassLookup getLookupFor(String className) {
         final ClassLoader cl = clRef.get();
-        return (cl == null) ? null : new ClassLookup(cl, className);
+        if (cl == null) {
+            return null;
+        }
+        return doPrivileged((PrivilegedAction<ClassLookup>)() -> {
+            final String resourceName = className + ".class";
+            URL res = cl.getResource(resourceName);
+            if (res == null) {
+                res = ClassLoader.getSystemResource(resourceName);
+                if (res == null) {
+                    res = getClass().getClassLoader().getResource(resourceName);
+                }
+            }
+            return new ClassLookup(cl, resourceName, res);
+        });
     }
 
     private String getDirectSuperClass(String className, URL resource) {
@@ -537,10 +550,10 @@ public final class MethodDatabase {
         private final String resourceName;
         private final URL resource;
 
-        ClassLookup(ClassLoader cl, String internalClassName) {
-            classloader = cl;
-            resourceName = internalClassName + ".class";
-            resource = doPrivileged((PrivilegedAction<URL>)() -> cl.getResource(resourceName));
+        ClassLookup(ClassLoader cl, String resourceName, URL resource) {
+            this.classloader = cl;
+            this.resourceName = resourceName;
+            this.resource = resource;
         }
 
         URL getResource() {

--- a/quasar-osgi-tests/build.gradle
+++ b/quasar-osgi-tests/build.gradle
@@ -107,7 +107,7 @@ def osgiTestResources = tasks.named('processOsgiTestResources', ProcessResources
     }
 }
 
-def testOSGi = tasks.register('testOSGi', TestOSGi) { task ->
+tasks.withType(TestOSGi).configureEach { task ->
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = of(testJavaVersion)
     }
@@ -126,15 +126,30 @@ def testOSGi = tasks.register('testOSGi', TestOSGi) { task ->
     }
 }
 
+def testOSGi = tasks.register('testOSGi', TestOSGi) {
+    ext {
+        // Felix enables implicit boot delegation by default.
+        bootDelegation = true
+    }
+}
+
+def testOSGiWithoutBootDelegation = tasks.register('testOSGiWithoutBootDelegation', TestOSGi) {
+    mustRunAfter testOSGi
+
+    ext {
+        bootDelegation = false
+    }
+}
+
 tasks.named('jar', Jar) {
     enabled = false
 }
 
 tasks.named('test', Test) {
-    dependsOn testOSGi
+    dependsOn testOSGi, testOSGiWithoutBootDelegation
     enabled = false
 }
 
 tasks.named('check') {
-    dependsOn testOSGi
+    dependsOn testOSGi, testOSGiWithoutBootDelegation
 }

--- a/quasar-osgi-tests/tests.bndrun
+++ b/quasar-osgi-tests/tests.bndrun
@@ -4,6 +4,9 @@
 -runee: JavaSE-17
 -runtrace: true
 
+# Enable debugging.
+# -runjdb: 1044
+
 -runvm: \
     -Dco.paralleluniverse.fibers.verifyInstrumentation,\
     -Djava.security.policy=all.policy,\
@@ -20,6 +23,7 @@
     co.paralleluniverse.quasar.excludePackages='aQute.**,kotlin**,org.osgi.**,org.apache.felix.**,org.junit.**,org.assertj.**,org.opentest4j**',\
     co.paralleluniverse.quasar.service,\
     co.paralleluniverse.quasar.verbose,\
+    felix.bootdelegation.implicit=${task.bootDelegation},\
     org.osgi.framework.bundle.parent=framework,\
     org.osgi.framework.security=osgi
 


### PR DESCRIPTION
Felix sets `felix.bootdelegation.implicit=true` by default, but this option can interfere with `java.util.ServiceLoader` inside an OSGi framework. For example, if a service to be loaded has implementations both _inside_ and _outside_ the framework then `ServiceLoader` may find the outside ones accidentally. Unfortunately, these implementations would not be assignable to the requested service interface, and so would trigger a `ServiceConfigurationError` exception.

Fix Quasar so that it also supports running with `felix.bootdelegation.implicit=false`.