### PR TITLE
ES-1571: Begin 0.7.17_r3-SNAPSHOT now that 0.7.16_r3 is released

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-quasarVersion=0.7.16_r3-SNAPSHOT
+quasarVersion=0.7.17_r3-SNAPSHOT
 kotlinVersion=1.3.72
 kotlinTestVersion=1.2.71
 taskTreeVersion=1.3.1


### PR DESCRIPTION
`0.7.16_r3` has been released, bumping to `.17 `snapshot in release/07 branch