### PR TITLE
ENT-12854 - Escrow build support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ kotlinVersion=1.3.72
 kotlinTestVersion=1.2.71
 taskTreeVersion=1.3.1
 shadowVersion=6.1.0
-artifactoryVersion=4.21.0
+artifactoryVersion=4.33.1
 assertjVersion=3.22.0
 bndVersion=6.2.0
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ import static org.gradle.api.JavaVersion.*
 
 pluginManagement {
     repositories {
+        mavenLocal()
         gradlePluginPortal()
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,17 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
+        maven {
+            name "R3 Maven remote repositories"
+            url "https://software.r3.com/artifactory/corda-remotes"
+            authentication {
+                basic(BasicAuthentication)
+            }
+            credentials {
+                username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+            }
+        }
     }
 
     plugins {

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,17 +4,6 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        maven {
-            name "R3 Maven remote repositories"
-            url "https://software.r3.com/artifactory/corda-remotes"
-            authentication {
-                basic(BasicAuthentication)
-            }
-            credentials {
-                username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
-                password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
-            }
-        }
     }
 
     plugins {


### PR DESCRIPTION
Added local maven to the list of plugin repositories.
This is to support builds by developers outside of R3, using the escrow archive of Corda Enterprise.

Also updated the version of the Artifactory plugin to 4.33.1 since 4.21.0 depends on `org.jfrog.buildinfo.build-info-extractor:2.23.0`, which is no longer available.
@adelel1 alternatively, preserve the version of the Artifactory plugin and add a reference to corda-remotes in the repos list in order to access build-info-extractor:2.23.0?